### PR TITLE
CellularNetworkManager: remove useless Build.VERSION_CODE checks

### DIFF
--- a/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
@@ -14,13 +14,13 @@ import android.os.Looper
 import android.telephony.TelephonyManager
 import android.util.Log
 import androidx.annotation.RequiresApi
+import org.json.JSONObject
 import java.net.URL
 import java.util.Timer
 import java.util.TimerTask
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.schedule
 import kotlin.concurrent.withLock
-import org.json.JSONObject
 
 internal class CellularNetworkManager(context: Context) : NetworkManager {
 
@@ -259,11 +259,7 @@ internal class CellularNetworkManager(context: Context) : NetworkManager {
     }
 
     private fun bind(network: Network?) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            ConnectivityManager.setProcessDefaultNetwork(network)
-        } else {
-            connectivityManager.bindProcessToNetwork(network) // API Level 23, 6.0 Marsh
-        }
+        connectivityManager.bindProcessToNetwork(network)
     }
 
     private fun requestNetwork(request: NetworkRequest, onCompletion: (isSuccess: Boolean) -> Unit) {
@@ -337,10 +333,8 @@ internal class CellularNetworkManager(context: Context) : NetworkManager {
     }
 
     private fun isCellularBoundToProcess(): Boolean {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) { // API 23
-            connectivityManager.boundNetworkForProcess?.let {
-                return isCellular(it)
-            }
+        connectivityManager.boundNetworkForProcess?.let {
+            return isCellular(it)
         }
         return false
     }
@@ -351,17 +345,13 @@ internal class CellularNetworkManager(context: Context) : NetworkManager {
     }
 
     private fun boundNetwork() { // API 23
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            tracer.addDebug(Log.DEBUG, TAG, "----- Bound network ----")
-            connectivityManager.boundNetworkForProcess?.let { networkInfo(it) }
-        }
+        tracer.addDebug(Log.DEBUG, TAG, "----- Bound network ----")
+        connectivityManager.boundNetworkForProcess?.let { networkInfo(it) }
     }
 
     private fun activeNetworkInfo() { // API 23
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            tracer.addDebug(Log.DEBUG, TAG, "---- Active network ----")
-            connectivityManager.activeNetwork?.let { networkInfo(it) }
-        }
+        tracer.addDebug(Log.DEBUG, TAG, "---- Active network ----")
+        connectivityManager.activeNetwork?.let { networkInfo(it) }
     }
 
     @RequiresApi(api = Build.VERSION_CODES.R) // 30


### PR DESCRIPTION
minSdk, defined in :client-library:build.gradle.kts, is already 24

Change-Id: I71b931964a6c0ff321d8618a4133fbf35c9df508