### PR TITLE
DEVX-11211/11210/11212: Enforce HTTPS-only connections, hostname verification, and block redirect downgrades

### DIFF
--- a/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
@@ -179,7 +179,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
             return convertError("sdk_error", "internal error")
         } catch (ex: Exception) {
             tracer.addDebug(Log.DEBUG, TAG, "Cannot complete post: $url")
-            return convertError("sdk_connection_error", "ex: ".plus(ex.localizedMessage ?: ex.toString()))
+            return convertError("sdk_connection_error", "Connection failed: ".plus(ex.localizedMessage ?: ex.toString()))
         } finally {
             if (this::socket.isInitialized && !socket.isClosed) {
                 try {

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
@@ -188,7 +188,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
                     tracer.addDebug(
                         Log.ERROR,
                         TAG,
-                        "Exception received whilst closing the socket ${e.localizedMessage}"
+                        "Exception received while closing the socket ${e.localizedMessage}"
                     )
                 }
             }

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
@@ -179,7 +179,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
             return convertError("sdk_error", "internal error")
         } catch (ex: Exception) {
             tracer.addDebug(Log.DEBUG, TAG, "Cannot complete post: $url")
-            return convertError("sdk_connection_error", "ex: ".plus(ex.localizedMessage))
+            return convertError("sdk_connection_error", "ex: ".plus(ex.localizedMessage ?: ex.toString()))
         } finally {
             if (this::socket.isInitialized && !socket.isClosed) {
                 stopConnection()

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
@@ -182,7 +182,15 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
             return convertError("sdk_connection_error", "ex: ".plus(ex.localizedMessage ?: ex.toString()))
         } finally {
             if (this::socket.isInitialized && !socket.isClosed) {
-                stopConnection()
+                try {
+                    stopConnection()
+                } catch (e: Exception) {
+                    tracer.addDebug(
+                        Log.ERROR,
+                        TAG,
+                        "Exception received whilst closing the socket ${e.localizedMessage}"
+                    )
+                }
             }
         }
     }

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
@@ -256,6 +256,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
         tracer.addTrace("\nStart connection ${url.host} ${url.port} ${url.protocol} ${DateUtils.now()}\n")
         try {
             val sslSocket = SSLSocketFactory.getDefault().createSocket(url.host, port) as SSLSocket
+            sslSocket.soTimeout = 5 * 1000
             val params = sslSocket.sslParameters
             params.endpointIdentificationAlgorithm = "HTTPS"
             sslSocket.sslParameters = params
@@ -272,7 +273,6 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
                 TAG,
                 "Client created : ${socket.inetAddress.hostAddress} ${socket.port}"
             )
-            socket.soTimeout = 5 * 1000
             output = socket.getOutputStream()
             input = BufferedReader(InputStreamReader(socket.inputStream))
             tracer.addDebug(

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
@@ -179,9 +179,9 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
             return convertError("sdk_error", "internal error")
         } catch (ex: Exception) {
             tracer.addDebug(Log.DEBUG, TAG, "Cannot complete post: $url")
-            return convertError("sdk_connection_error", "Connection failed: ".plus(ex.localizedMessage ?: ex.toString()))
+            return convertError("sdk_connection_error", "Connection failed: ${ex.localizedMessage ?: ex}")
         } finally {
-            if (this::socket.isInitialized && !socket.isClosed) {
+            if (this::socket.isInitialized) {
                 try {
                     stopConnection()
                 } catch (e: Exception) {

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
@@ -169,14 +169,22 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
     }
 
     fun post(url: URL, headers: Map<String, String>, body: String?): JSONObject {
-        startConnection(url)
-        val request = makePost(url, headers, body)
-        val response = sendAndReceive(request)
-        stopConnection()
-        if (response != null) {
-            return convertResultHandler(response)
+        try {
+            startConnection(url)
+            val request = makePost(url, headers, body)
+            val response = sendAndReceive(request)
+            if (response != null) {
+                return convertResultHandler(response)
+            }
+            return convertError("sdk_error", "internal error")
+        } catch (ex: Exception) {
+            tracer.addDebug(Log.DEBUG, TAG, "Cannot complete post: $url")
+            return convertError("sdk_connection_error", "ex: ".plus(ex.localizedMessage))
+        } finally {
+            if (this::socket.isInitialized && !socket.isClosed) {
+                stopConnection()
+            }
         }
-        return convertError("sdk_error", "internal error")
     }
 
     private fun makeHTTPCommand(

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
@@ -12,6 +12,7 @@ import java.net.URL
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.util.UUID
+import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
 import org.json.JSONException
 import org.json.JSONObject
@@ -88,9 +89,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
         cmd.append("POST " + url.path)
         cmd.append(" HTTP/1.1$CRLF")
         cmd.append("Host: " + url.host)
-        if (url.protocol == "https" && url.port > 0 && url.port != PORT_443) {
-            cmd.append(":" + url.port)
-        } else if (url.protocol == "http" && url.port > 0 && url.port != PORT_80) {
+        if (url.port > 0 && url.port != PORT_443) {
             cmd.append(":" + url.port)
         }
         cmd.append(CRLF)
@@ -198,9 +197,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
         }
         cmd.append(" HTTP/1.1$CRLF")
         cmd.append("Host: " + url.host)
-        if (url.protocol == "https" && url.port > 0 && url.port != PORT_443) {
-            cmd.append(":" + url.port)
-        } else if (url.protocol == "http" && url.port > 0 && url.port != PORT_80) {
+        if (url.port > 0 && url.port != PORT_443) {
             cmd.append(":" + url.port)
         }
         cmd.append(CRLF)
@@ -250,18 +247,20 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
     }
 
     private fun startConnection(url: URL) {
-        var port = PORT_80
+        if (url.protocol != "https") {
+            throw IOException("Only HTTPS URLs are supported. Received: ${url.protocol}://")
+        }
+        var port = PORT_443
         if (url.port > 0) port = url.port
         tracer.addDebug(Log.DEBUG, TAG, "start : ${url.host} ${url.port} ${url.protocol}")
         tracer.addTrace("\nStart connection ${url.host} ${url.port} ${url.protocol} ${DateUtils.now()}\n")
         try {
-            socket = if (url.protocol == "https") {
-                port = PORT_443
-                if (url.port > 0) port = url.port
-                SSLSocketFactory.getDefault().createSocket(url.host, port)
-            } else {
-                Socket(url.host, port)
-            }
+            val sslSocket = SSLSocketFactory.getDefault().createSocket(url.host, port) as SSLSocket
+            val params = sslSocket.sslParameters
+            params.endpointIdentificationAlgorithm = "HTTPS"
+            sslSocket.sslParameters = params
+            sslSocket.startHandshake()
+            socket = sslSocket
         } catch (ex: Exception) {
             tracer.addDebug(Log.ERROR, TAG, "Cannot create socket exception : ${ex.message}")
             tracer.addTrace("Cannot create socket exception ${ex.message}\n")
@@ -404,12 +403,18 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
             // some location header are not properly encoded
             var cleanRedirect = redirect.replace(" ", "+")
             tracer.addDebug(Log.DEBUG, TAG, "cleanRedirect : $cleanRedirect")
-            if (!cleanRedirect.startsWith("http")) { // http & https
+            if (!cleanRedirect.startsWith("http")) { // relative redirect
                 return ResultHandler(httpStatus, URL(requestURL, cleanRedirect), null, cookies)
+            }
+            val redirectUrl = URL(cleanRedirect)
+            if (requestURL.protocol == "https" && redirectUrl.protocol == "http") {
+                tracer.addDebug(Log.DEBUG, TAG, "Blocked HTTPS-to-HTTP redirect downgrade")
+                tracer.addTrace("Blocked HTTPS-to-HTTP redirect downgrade\n")
+                return null
             }
             tracer.addDebug(Log.DEBUG, TAG, "Found redirect")
             tracer.addTrace("Found redirect - ${DateUtils.now()} \n")
-            return ResultHandler(httpStatus, URL(cleanRedirect), null, cookies)
+            return ResultHandler(httpStatus, redirectUrl, null, cookies)
         }
         return null
     }
@@ -455,7 +460,6 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
     companion object {
         private const val TAG = "CellularClient"
         private const val HEADER_USER_AGENT = "User-Agent"
-        private const val PORT_80 = 80
         private const val PORT_443 = 443
         private const val CRLF = "\r\n"
     }


### PR DESCRIPTION
## Summary

Addresses three P1 security issues identified in the DEVX-11185 audit, all in `ClientSocket.kt`.

### DEVX-11211 — Plain HTTP Connections Allowed
Rejects any non-HTTPS URL at the top of `startConnection()` with an `IOException`. The SDK transmits auth tokens and operator identity data — plain HTTP is unacceptable.

### DEVX-11210 — No TLS Certificate Hostname Verification
After creating the `SSLSocket`, explicitly sets `sslParameters.endpointIdentificationAlgorithm = "HTTPS"` and calls `startHandshake()` before any data is exchanged. Previously, a certificate for `attacker.com` would have been accepted for any host.

### DEVX-11212 — HTTPS-to-HTTP Redirect Downgrade
In `parseRedirect()`, checks that the resolved redirect URL does not downgrade from `https://` to `http://`. If a downgrade is detected the redirect is silently dropped and the caller receives `null`, preventing a MITM attacker from stripping TLS via a crafted `Location` header.

### Cleanup
- Removed unused `PORT_80` constant (HTTP port is no longer a valid path).
- Removed dead `http` branches from `makePost()` and `makeHTTPCommand()`.
- Reuses already-parsed `redirectUrl` object in `parseRedirect()` instead of re-parsing the string.

## Jira Tickets
- https://jira.vonage.com/browse/DEVX-11211
- https://jira.vonage.com/browse/DEVX-11210
- https://jira.vonage.com/browse/DEVX-11212

## Part of Epic
https://jira.vonage.com/browse/DEVX-11185