### PR TITLE
DEVX-11213: Gate sensitive HTTP request/response logging behind Debug builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Potential error codes: `sdk_no_data_connectivity`, `sdk_connection_error`, `sdk_
 
 ## Logging
 
-The SDK logs detailed request and response data (URLs, headers, body content) to help with debugging. This output is gated behind `BuildConfig.DEBUG` and is **only emitted in debug builds** — it is automatically suppressed in release builds.
+The SDK logs detailed request and response data (URLs, headers, body content) to help with debugging. This output is gated behind the host app's debuggable flag (`ApplicationInfo.FLAG_DEBUGGABLE`) and is **only emitted when your app is built as debuggable** — it is automatically suppressed in release builds.
 
-If you need to inspect SDK network activity during development, build and run your app in debug mode and filter logcat by the `ClientSocket` tag.
+If you need to inspect SDK network activity during development, build and run your app in debug mode and filter logcat by the `CellularClient` tag.
 
 ## Migrating from `com.vonage:client-sdk-silent-auth` or `com.vonage:client-sdk-number-verification`
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ if (response.optString("error") != "") {
 
 Potential error codes: `sdk_no_data_connectivity`, `sdk_connection_error`, `sdk_redirect_error`, `sdk_error`.
 
+## Logging
+
+The SDK logs detailed request and response data (URLs, headers, body content) to help with debugging. This output is gated behind `BuildConfig.DEBUG` and is **only emitted in debug builds** — it is automatically suppressed in release builds.
+
+If you need to inspect SDK network activity during development, build and run your app in debug mode and filter logcat by the `ClientSocket` tag.
+
 ## Migrating from `com.vonage:client-sdk-silent-auth` or `com.vonage:client-sdk-number-verification`
 
 `com.vonage:client-library` replaces both `com.vonage:client-sdk-silent-auth` and `com.vonage:client-sdk-number-verification`

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
@@ -2,6 +2,7 @@ package com.vonage.clientlibrary.network
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
@@ -27,6 +28,9 @@ internal class CellularNetworkManager(context: Context) : NetworkManager {
     private val cellularInfo by lazy {
         context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
     }
+
+    private val isDebuggable: Boolean =
+        (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
 
     private val connectivityManager by lazy {
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
@@ -62,7 +66,7 @@ internal class CellularNetworkManager(context: Context) : NetworkManager {
                 }
                 // We have Mobile Data registered and bound for use
                 // However, user may still have no data plan!
-                val cs = ClientSocket()
+                val cs = ClientSocket(isDebuggable = isDebuggable)
                 if (debug) tracer.startTrace()
                 response = cs.open(url, headers, getOperator(), maxRedirectCount)
                 if (debug) {
@@ -92,7 +96,7 @@ internal class CellularNetworkManager(context: Context) : NetworkManager {
             if (it) {
                 // We have Mobile Data registered and bound for use
                 // However, user may still have no data plan!
-                val cs = ClientSocket()
+                val cs = ClientSocket(isDebuggable = isDebuggable)
                 response = cs.post(url, headers, body)
             } else {
                 tracer.addDebug(Log.DEBUG, TAG, "We do not have a path")

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
@@ -135,8 +135,10 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
             response?.let {
                 val lines = response.split("\n")
                 for (line in lines) {
-                    if (BuildConfig.DEBUG) tracer.addDebug(Log.DEBUG, TAG, line)
-                    tracer.addTrace(line)
+                    if (BuildConfig.DEBUG) {
+                        tracer.addDebug(Log.DEBUG, TAG, line)
+                        tracer.addTrace(line)
+                    }
                     if (line.startsWith("HTTP/")) {
                         val parts = line.split(" ")
                         if (parts.isNotEmpty() && parts.size >= 2) {
@@ -300,8 +302,8 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
     ): ResultHandler? {
         if (BuildConfig.DEBUG) {
             tracer.addDebug(Log.DEBUG, TAG, "Client sending \n$message\n")
+            tracer.addTrace(message)
         }
-        tracer.addTrace(message)
         try {
             val bytesOfRequest: ByteArray =
                 message.toByteArray(Charset.forName(StandardCharsets.UTF_8.name()))
@@ -328,8 +330,10 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
             response?.let {
                 val lines = response.split("\n")
                 for (line in lines) {
-                    if (BuildConfig.DEBUG) tracer.addDebug(Log.DEBUG, TAG, line)
-                    tracer.addTrace(line)
+                    if (BuildConfig.DEBUG) {
+                        tracer.addDebug(Log.DEBUG, TAG, line)
+                        tracer.addTrace(line)
+                    }
                     if (line.startsWith("HTTP/")) {
                         val parts = line.split(" ")
                         if (parts.isNotEmpty() && parts.size >= 2) {
@@ -343,11 +347,13 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
                             try {
                                 for (cookie in HttpCookie.parse(parts[1])) {
                                     cookies.add(cookie)
-                                    if (BuildConfig.DEBUG) tracer.addDebug(Log.DEBUG, TAG, "cookie - $cookie")
-                                    tracer.addTrace("cookie - $cookie\n")
+                                    if (BuildConfig.DEBUG) {
+                                        tracer.addDebug(Log.DEBUG, TAG, "cookie - $cookie")
+                                        tracer.addTrace("cookie - $cookie\n")
+                                    }
                                 }
                             } catch (ex: IllegalArgumentException) {
-                                tracer.addTrace("Cannot parse cookie ${parts[1]}  ${ex.message}\n")
+                                tracer.addTrace("Cannot parse cookie ${ex.message}\n")
                             }
                         }
                     } else if (line.contains("Location:") || line.contains("location:")) {
@@ -369,7 +375,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
                     }
                 }
                 if (BuildConfig.DEBUG) tracer.addDebug(Log.DEBUG, TAG, "Status - $status\nBody - $body\n")
-                tracer.addTrace("Status - $status ${DateUtils.now()}\nBody - $body\n")
+                tracer.addTrace("Status - $status ${DateUtils.now()}\n")
                 result = if (result != null)
                     return result
                 else if (bodyBegin && body != null) {

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
@@ -2,7 +2,6 @@ package com.vonage.clientlibrary.network
 
 import android.os.Build
 import android.util.Log
-import com.vonage.clientlibrary.BuildConfig
 import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.io.OutputStream
@@ -17,7 +16,10 @@ import javax.net.ssl.SSLSocketFactory
 import org.json.JSONException
 import org.json.JSONObject
 
-internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollector.instance) {
+internal class ClientSocket constructor(
+    var tracer: TraceCollector = TraceCollector.instance,
+    private val isDebuggable: Boolean = false
+) {
     private lateinit var socket: Socket
     private lateinit var output: OutputStream
     private lateinit var input: BufferedReader
@@ -111,7 +113,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
     }
 
     private fun sendAndReceive(request: String): ResponseHandler? {
-        if (BuildConfig.DEBUG) tracer.addDebug(Log.DEBUG, TAG, "Client sending \n$request\n")
+        if (isDebuggable) tracer.addDebug(Log.DEBUG, TAG, "Client sending \n$request\n")
         try {
             val bytesOfRequest: ByteArray =
                 request.toByteArray(Charset.forName(StandardCharsets.UTF_8.name()))
@@ -128,14 +130,14 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
         var chunked: Boolean = false
         try {
             var response: String? = readMultipleChars(input, 65536)
-            if (BuildConfig.DEBUG) {
+            if (isDebuggable) {
                 tracer.addDebug(Log.DEBUG, TAG, "$response \n")
                 tracer.addDebug(Log.DEBUG, TAG, "--------\n")
             }
             response?.let {
                 val lines = response.split("\n")
                 for (line in lines) {
-                    if (BuildConfig.DEBUG) {
+                    if (isDebuggable) {
                         tracer.addDebug(Log.DEBUG, TAG, line)
                         tracer.addTrace(line)
                     }
@@ -154,7 +156,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
                         // do nothing
                     } else {
                         body += line.replace("\r", "")
-                        if (BuildConfig.DEBUG) tracer.addDebug(Log.DEBUG, TAG, "Adding to body - $body\n")
+                        if (isDebuggable) tracer.addDebug(Log.DEBUG, TAG, "Adding to body - $body\n")
                     }
                 }
                 if (chunked && !body.isNullOrBlank()) {
@@ -164,7 +166,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
                         body = body.substring(r1, r2 + 1)
                     }
                 }
-                if (BuildConfig.DEBUG) tracer.addDebug(Log.DEBUG, TAG, "Status - $status [$chunked]\nBody - $body\n")
+                if (isDebuggable) tracer.addDebug(Log.DEBUG, TAG, "Status - $status [$chunked]\nBody - $body\n")
                 result = ResponseHandler(status, body)
             }
         } catch (ex: Exception) {
@@ -300,7 +302,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
         message: String,
         existingCookies: ArrayList<HttpCookie>?
     ): ResultHandler? {
-        if (BuildConfig.DEBUG) {
+        if (isDebuggable) {
             tracer.addDebug(Log.DEBUG, TAG, "Client sending \n$message\n")
             tracer.addTrace(message)
         }
@@ -330,7 +332,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
             response?.let {
                 val lines = response.split("\n")
                 for (line in lines) {
-                    if (BuildConfig.DEBUG) {
+                    if (isDebuggable) {
                         tracer.addDebug(Log.DEBUG, TAG, line)
                         tracer.addTrace(line)
                     }
@@ -347,7 +349,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
                             try {
                                 for (cookie in HttpCookie.parse(parts[1])) {
                                     cookies.add(cookie)
-                                    if (BuildConfig.DEBUG) {
+                                    if (isDebuggable) {
                                         tracer.addDebug(Log.DEBUG, TAG, "cookie - $cookie")
                                         tracer.addTrace("cookie - $cookie\n")
                                     }
@@ -371,10 +373,10 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
                             "\r",
                             ""
                         )
-                        if (BuildConfig.DEBUG) tracer.addDebug(Log.DEBUG, TAG, "Adding to body - $body\n")
+                        if (isDebuggable) tracer.addDebug(Log.DEBUG, TAG, "Adding to body - $body\n")
                     }
                 }
-                if (BuildConfig.DEBUG) tracer.addDebug(Log.DEBUG, TAG, "Status - $status\nBody - $body\n")
+                if (isDebuggable) tracer.addDebug(Log.DEBUG, TAG, "Status - $status\nBody - $body\n")
                 tracer.addTrace("Status - $status ${DateUtils.now()}\n")
                 result = if (result != null)
                     return result

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
@@ -2,6 +2,7 @@ package com.vonage.clientlibrary.network
 
 import android.os.Build
 import android.util.Log
+import com.vonage.clientlibrary.BuildConfig
 import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.io.OutputStream
@@ -110,7 +111,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
     }
 
     private fun sendAndReceive(request: String): ResponseHandler? {
-        tracer.addDebug(Log.DEBUG, TAG, "Client sending \n$request\n")
+        if (BuildConfig.DEBUG) tracer.addDebug(Log.DEBUG, TAG, "Client sending \n$request\n")
         try {
             val bytesOfRequest: ByteArray =
                 request.toByteArray(Charset.forName(StandardCharsets.UTF_8.name()))
@@ -127,12 +128,14 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
         var chunked: Boolean = false
         try {
             var response: String? = readMultipleChars(input, 65536)
-            tracer.addDebug(Log.DEBUG, TAG, "$response \n")
-            tracer.addDebug(Log.DEBUG, TAG, "--------" + "\n")
+            if (BuildConfig.DEBUG) {
+                tracer.addDebug(Log.DEBUG, TAG, "$response \n")
+                tracer.addDebug(Log.DEBUG, TAG, "--------\n")
+            }
             response?.let {
                 val lines = response.split("\n")
                 for (line in lines) {
-                    tracer.addDebug(Log.DEBUG, TAG, line)
+                    if (BuildConfig.DEBUG) tracer.addDebug(Log.DEBUG, TAG, line)
                     tracer.addTrace(line)
                     if (line.startsWith("HTTP/")) {
                         val parts = line.split(" ")
@@ -149,7 +152,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
                         // do nothing
                     } else {
                         body += line.replace("\r", "")
-                        tracer.addDebug(Log.DEBUG, TAG, "Adding to body - $body\n")
+                        if (BuildConfig.DEBUG) tracer.addDebug(Log.DEBUG, TAG, "Adding to body - $body\n")
                     }
                 }
                 if (chunked && !body.isNullOrBlank()) {
@@ -159,7 +162,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
                         body = body.substring(r1, r2 + 1)
                     }
                 }
-                tracer.addDebug(Log.DEBUG, TAG, "Status - $status [$chunked]\nBody - $body\n")
+                if (BuildConfig.DEBUG) tracer.addDebug(Log.DEBUG, TAG, "Status - $status [$chunked]\nBody - $body\n")
                 result = ResponseHandler(status, body)
             }
         } catch (ex: Exception) {
@@ -295,7 +298,9 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
         message: String,
         existingCookies: ArrayList<HttpCookie>?
     ): ResultHandler? {
-        tracer.addDebug(Log.DEBUG, TAG, "Client sending \n$message\n")
+        if (BuildConfig.DEBUG) {
+            tracer.addDebug(Log.DEBUG, TAG, "Client sending \n$message\n")
+        }
         tracer.addTrace(message)
         try {
             val bytesOfRequest: ByteArray =
@@ -323,7 +328,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
             response?.let {
                 val lines = response.split("\n")
                 for (line in lines) {
-                    tracer.addDebug(Log.DEBUG, TAG, line)
+                    if (BuildConfig.DEBUG) tracer.addDebug(Log.DEBUG, TAG, line)
                     tracer.addTrace(line)
                     if (line.startsWith("HTTP/")) {
                         val parts = line.split(" ")
@@ -338,7 +343,7 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
                             try {
                                 for (cookie in HttpCookie.parse(parts[1])) {
                                     cookies.add(cookie)
-                                    tracer.addDebug(Log.DEBUG, TAG, "cookie - $cookie")
+                                    if (BuildConfig.DEBUG) tracer.addDebug(Log.DEBUG, TAG, "cookie - $cookie")
                                     tracer.addTrace("cookie - $cookie\n")
                                 }
                             } catch (ex: IllegalArgumentException) {
@@ -360,10 +365,10 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
                             "\r",
                             ""
                         )
-                        tracer.addDebug(Log.DEBUG, TAG, "Adding to body - $body\n")
+                        if (BuildConfig.DEBUG) tracer.addDebug(Log.DEBUG, TAG, "Adding to body - $body\n")
                     }
                 }
-                tracer.addDebug(Log.DEBUG, TAG, "Status - $status\nBody - $body\n")
+                if (BuildConfig.DEBUG) tracer.addDebug(Log.DEBUG, TAG, "Status - $status\nBody - $body\n")
                 tracer.addTrace("Status - $status ${DateUtils.now()}\nBody - $body\n")
                 result = if (result != null)
                     return result


### PR DESCRIPTION
## Summary

Full HTTP request and response content — including auth tokens, cookies, and body payloads — were being emitted to logcat on every request via `Log.d()`. This exposes credentials to any app with `READ_LOGS` permission.

### Changes
- Full outbound request strings (headers + body) are now gated behind `BuildConfig.DEBUG` in both `sendAndReceive` overloads
- Full inbound response dump, per-line response logging, cookie values, and body content are similarly gated
- Status codes and non-sensitive structural logs (connection open/close, redirect detected) remain in production to aid diagnosing failures without leaking data

## Jira Ticket
https://jira.vonage.com/browse/DEVX-11213

## Part of Epic
https://jira.vonage.com/browse/DEVX-11185