### PR TITLE
DEVX-11220: Fix deadlock and lost-signal race in CellularNetworkManager.execute()

### DIFF
--- a/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
@@ -146,10 +146,17 @@ internal class CellularNetworkManager(context: Context) : NetworkManager {
             }
 
             lock.withLock {
-                // Guard against the lost-signal race: if the callback already fired
-                // and set signaled=true before we reached await(), skip the wait.
-                if (!signaled) {
-                    condition.await(EXECUTE_TIMEOUT, TimeUnit.MILLISECONDS)
+                // Guard against lost-signal race and spurious wakeups:
+                // loop on the predicate so spurious wakeups are re-checked, and
+                // skip the wait entirely if the callback already fired.
+                while (!signaled) {
+                    val timedOut = !condition.await(EXECUTE_TIMEOUT, TimeUnit.MILLISECONDS)
+                    if (timedOut && !signaled) {
+                        // Timeout with no completion — call onCompletion(false) exactly once.
+                        signaled = true
+                        onCompletion(false)
+                        break
+                    }
                 }
             }
         } catch (ex: Exception) {

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
@@ -146,17 +146,10 @@ internal class CellularNetworkManager(context: Context) : NetworkManager {
             }
 
             lock.withLock {
-                // Guard against lost-signal race and spurious wakeups:
-                // loop on the predicate so spurious wakeups are re-checked, and
-                // skip the wait entirely if the callback already fired.
-                while (!signaled) {
-                    val timedOut = !condition.await(EXECUTE_TIMEOUT, TimeUnit.MILLISECONDS)
-                    if (timedOut && !signaled) {
-                        // Timeout with no completion — call onCompletion(false) exactly once.
-                        signaled = true
-                        onCompletion(false)
-                        break
-                    }
+                // Guard against the lost-signal race: if the callback already fired
+                // and set signaled=true before we reached await(), skip the wait.
+                if (!signaled) {
+                    condition.await(EXECUTE_TIMEOUT, TimeUnit.MILLISECONDS)
                 }
             }
         } catch (ex: Exception) {

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
@@ -18,6 +18,7 @@ import androidx.annotation.RequiresApi
 import java.net.URL
 import java.util.Timer
 import java.util.TimerTask
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.schedule
 import kotlin.concurrent.withLock
@@ -129,6 +130,7 @@ internal class CellularNetworkManager(context: Context) : NetworkManager {
         try {
             val lock = ReentrantLock()
             val condition = lock.newCondition()
+            var signaled = false
 
             val capabilities = intArrayOf(NetworkCapabilities.NET_CAPABILITY_INTERNET)
             val transportTypes = intArrayOf(NetworkCapabilities.TRANSPORT_CELLULAR)
@@ -138,12 +140,17 @@ internal class CellularNetworkManager(context: Context) : NetworkManager {
                     // We have Mobile Data registered and bound for use
                     // However, user may still have no data plan!
                     onCompletion(isOnCellular)
+                    signaled = true
                     condition.signal()
                 }
             }
 
             lock.withLock {
-                condition.await()
+                // Guard against the lost-signal race: if the callback already fired
+                // and set signaled=true before we reached await(), skip the wait.
+                if (!signaled) {
+                    condition.await(EXECUTE_TIMEOUT, TimeUnit.MILLISECONDS)
+                }
             }
         } catch (ex: Exception) {
             tracer.addDebug(Log.ERROR, TAG, "execute exception ${ex.message}")
@@ -369,6 +376,8 @@ internal class CellularNetworkManager(context: Context) : NetworkManager {
     companion object {
         private const val TAG = "CellularNetworkManager"
         private const val TIME_OUT: Long = 5000
+        /** Slightly longer than TIME_OUT to allow the network callback to fire first. */
+        private const val EXECUTE_TIMEOUT: Long = 6000
     }
 
     private fun boundNetwork() { // API 23

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
@@ -137,19 +137,24 @@ internal class CellularNetworkManager(context: Context) : NetworkManager {
 
             forceCellular(capabilities, transportTypes) { isOnCellular ->
                 lock.withLock {
-                    // We have Mobile Data registered and bound for use
-                    // However, user may still have no data plan!
-                    onCompletion(isOnCellular)
-                    signaled = true
-                    condition.signal()
+                    if (!signaled) {
+                        signaled = true
+                        onCompletion(isOnCellular)
+                        condition.signal()
+                    }
                 }
             }
 
             lock.withLock {
-                // Guard against the lost-signal race: if the callback already fired
-                // and set signaled=true before we reached await(), skip the wait.
+                val deadline = System.currentTimeMillis() + EXECUTE_TIMEOUT
+                while (!signaled) {
+                    val remaining = deadline - System.currentTimeMillis()
+                    if (remaining <= 0 || !condition.await(remaining, TimeUnit.MILLISECONDS)) break
+                }
                 if (!signaled) {
-                    condition.await(EXECUTE_TIMEOUT, TimeUnit.MILLISECONDS)
+                    signaled = true
+                    tracer.addDebug(Log.DEBUG, TAG, "execute timed out waiting for cellular callback")
+                    onCompletion(false)
                 }
             }
         } catch (ex: Exception) {

--- a/client-library/src/test/java/com/vonage/clientlibrary/network/CellularNetworkManagerTest.kt
+++ b/client-library/src/test/java/com/vonage/clientlibrary/network/CellularNetworkManagerTest.kt
@@ -1,0 +1,145 @@
+package com.vonage.clientlibrary.network
+
+import org.junit.Assert.*
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Tests for the execute() concurrency contract in CellularNetworkManager:
+ * - onCompletion is called exactly once even if the callback fires after a timeout
+ * - spurious wakeups are handled (loop continues waiting)
+ * - timeout calls onCompletion(false)
+ *
+ * These tests replicate the lock/condition/signaled pattern used in execute() directly,
+ * since CellularNetworkManager requires Android system services that can't be unit-tested.
+ */
+class CellularNetworkManagerTest {
+
+    /**
+     * Simulates the execute() logic: the callback fires before the timeout expires.
+     * onCompletion should be called exactly once with true.
+     */
+    @Test
+    fun `execute logic calls onCompletion once when callback fires before timeout`() {
+        val lock = ReentrantLock()
+        val condition = lock.newCondition()
+        var signaled = false
+        val completions = mutableListOf<Boolean>()
+        val timeoutMs = 500L
+
+        // Simulate forceCellular firing the callback immediately on another thread
+        Thread {
+            Thread.sleep(50)
+            lock.withLock {
+                if (!signaled) {
+                    signaled = true
+                    completions.add(true)
+                    condition.signal()
+                }
+            }
+        }.start()
+
+        // Simulate the await loop from execute()
+        lock.withLock {
+            val deadline = System.currentTimeMillis() + timeoutMs
+            while (!signaled) {
+                val remaining = deadline - System.currentTimeMillis()
+                if (remaining <= 0 || !condition.await(remaining, TimeUnit.MILLISECONDS)) break
+            }
+            if (!signaled) {
+                signaled = true
+                completions.add(false)
+            }
+        }
+
+        assertEquals("onCompletion should be called exactly once", 1, completions.size)
+        assertTrue("onCompletion should be called with true", completions[0])
+    }
+
+    /**
+     * Simulates execute() timing out: callback never fires.
+     * onCompletion(false) should be called exactly once.
+     */
+    @Test
+    fun `execute logic calls onCompletion(false) exactly once on timeout`() {
+        val lock = ReentrantLock()
+        val condition = lock.newCondition()
+        var signaled = false
+        val completions = mutableListOf<Boolean>()
+        val timeoutMs = 100L
+
+        // forceCellular fires late — after the timeout
+        Thread {
+            Thread.sleep(300)
+            lock.withLock {
+                if (!signaled) {
+                    signaled = true
+                    completions.add(true) // this should NOT happen
+                    condition.signal()
+                }
+            }
+        }.start()
+
+        lock.withLock {
+            val deadline = System.currentTimeMillis() + timeoutMs
+            while (!signaled) {
+                val remaining = deadline - System.currentTimeMillis()
+                if (remaining <= 0 || !condition.await(remaining, TimeUnit.MILLISECONDS)) break
+            }
+            if (!signaled) {
+                signaled = true
+                completions.add(false)
+            }
+        }
+
+        // Give the late callback thread time to try to fire
+        Thread.sleep(400)
+
+        assertEquals("onCompletion should be called exactly once", 1, completions.size)
+        assertFalse("onCompletion should be called with false on timeout", completions[0])
+    }
+
+    /**
+     * Simulates a race where the callback fires at the same time as the timeout.
+     * onCompletion should still only be called once.
+     */
+    @Test
+    fun `execute logic prevents double-completion on race between callback and timeout`() {
+        repeat(20) { // run many times to expose races
+            val lock = ReentrantLock()
+            val condition = lock.newCondition()
+            var signaled = false
+            var completionCount = 0
+            val timeoutMs = 50L
+
+            // Callback fires at exactly the same time as timeout
+            Thread {
+                Thread.sleep(timeoutMs)
+                lock.withLock {
+                    if (!signaled) {
+                        signaled = true
+                        completionCount++
+                        condition.signal()
+                    }
+                }
+            }.start()
+
+            lock.withLock {
+                val deadline = System.currentTimeMillis() + timeoutMs
+                while (!signaled) {
+                    val remaining = deadline - System.currentTimeMillis()
+                    if (remaining <= 0 || !condition.await(remaining, TimeUnit.MILLISECONDS)) break
+                }
+                if (!signaled) {
+                    signaled = true
+                    completionCount++
+                }
+            }
+
+            Thread.sleep(100) // let late callback thread finish
+            assertEquals("onCompletion called more than once in iteration $it", 1, completionCount)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`execute()` used `condition.await()` without a timeout and had a race condition where `signal()` could fire before `await()` was reached, causing the thread to block permanently.

### Changes
- **Timeout**: replaced `condition.await()` with `condition.await(6000, TimeUnit.MILLISECONDS)` — if the network callback never fires, the thread unblocks after 6 seconds and `onCompletion(false)` is returned
- Added `EXECUTE_TIMEOUT = 6000ms` constant (1s beyond `TIME_OUT` to give the network callback a chance to fire first)

## Jira Ticket
https://jira.vonage.com/browse/DEVX-11220

## Part of Epic
https://jira.vonage.com/browse/DEVX-11185