### PR TITLE
DEVX-11214/11215/11216: Context leak fix, URL input validation, RFC-compliant cookie domain matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import com.vonage.clientlibrary.VGCellularRequestParameters
 VGCellularRequestClient.initializeSdk(this.applicationContext)
 
 val params = VGCellularRequestClientParameters(
-    url = "https://www.vonage.com",
+    url = "http://www.vonage.com",
     headers = mapOf("x-my-header" to "My Value") ,
     queryParameters = mapOf("query-param" to "value"),
     maxRedirectCount = 10
@@ -45,7 +45,6 @@ if (response.optString("error") != "") {
 ```
 * `maxRedirectCount` in `VGCellularRequestParameters` is an optional and defaults to 10.
 * `debug` parameter for `startCellularRequest` is optional and defaults to false.
-* Only `https://` URLs are accepted. Passing an `http://` URL will throw a `MalformedURLException`.
 
 #### Responses
 
@@ -148,7 +147,7 @@ or
 ```kotlin
 // com.vonage:client-sdk-number-verification
 val params = VGNumberVerificationParameters(
-        url = "https://www.vonage.com",
+        url = "http://www.vonage.com",
         headers = mapOf("x-my-header" to "My Value") ,
         queryParameters = mapOf("query-param" to "value"),
         maxRedirectCount = 10

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import com.vonage.clientlibrary.VGCellularRequestParameters
 VGCellularRequestClient.initializeSdk(this.applicationContext)
 
 val params = VGCellularRequestClientParameters(
-    url = "http://www.vonage.com",
+    url = "https://www.vonage.com",
     headers = mapOf("x-my-header" to "My Value") ,
     queryParameters = mapOf("query-param" to "value"),
     maxRedirectCount = 10
@@ -45,6 +45,7 @@ if (response.optString("error") != "") {
 ```
 * `maxRedirectCount` in `VGCellularRequestParameters` is an optional and defaults to 10.
 * `debug` parameter for `startCellularRequest` is optional and defaults to false.
+* Only `https://` URLs are accepted. Passing an `http://` URL will throw a `MalformedURLException`.
 
 #### Responses
 
@@ -147,7 +148,7 @@ or
 ```kotlin
 // com.vonage:client-sdk-number-verification
 val params = VGNumberVerificationParameters(
-        url = "http://www.vonage.com",
+        url = "https://www.vonage.com",
         headers = mapOf("x-my-header" to "My Value") ,
         queryParameters = mapOf("query-param" to "value"),
         maxRedirectCount = 10

--- a/client-library/src/main/java/com/vonage/clientlibrary/VGCellularRequestClient.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/VGCellularRequestClient.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import com.vonage.clientlibrary.network.CellularNetworkManager
 import com.vonage.clientlibrary.network.NetworkManager
 import org.json.JSONObject
+import java.net.MalformedURLException
 import java.net.URL
 
 class VGCellularRequestClient private constructor(networkManager: CellularNetworkManager) {
@@ -36,7 +37,14 @@ class VGCellularRequestClient private constructor(networkManager: CellularNetwor
             uriBuilder.appendQueryParameter(key, value)
         }
         val uri = uriBuilder.build().toString()
-        return URL(uri)
+        val url = URL(uri)
+        if (url.protocol != "https") {
+            throw MalformedURLException("Only HTTPS URLs are supported. Received: ${url.protocol}://")
+        }
+        if (url.host.isNullOrEmpty()) {
+            throw MalformedURLException("URL must contain a non-empty host.")
+        }
+        return url
     }
 
     companion object {
@@ -48,7 +56,7 @@ class VGCellularRequestClient private constructor(networkManager: CellularNetwor
             var currentInstance = instance
             if (null == currentInstance || currentContext != context) {
                 val nm = CellularNetworkManager(context)
-                currentContext = context
+                currentContext = context.applicationContext
                 currentInstance = VGCellularRequestClient(nm)
             }
             instance = currentInstance

--- a/client-library/src/main/java/com/vonage/clientlibrary/VGCellularRequestClient.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/VGCellularRequestClient.kt
@@ -53,10 +53,11 @@ class VGCellularRequestClient private constructor(networkManager: CellularNetwor
 
         @Synchronized
         fun initializeSdk(context: Context): VGCellularRequestClient {
+            val appContext = context.applicationContext
             var currentInstance = instance
-            if (null == currentInstance || currentContext != context) {
-                val nm = CellularNetworkManager(context)
-                currentContext = context.applicationContext
+            if (null == currentInstance || currentContext != appContext) {
+                val nm = CellularNetworkManager(appContext)
+                currentContext = appContext
                 currentInstance = VGCellularRequestClient(nm)
             }
             instance = currentInstance

--- a/client-library/src/main/java/com/vonage/clientlibrary/VGCellularRequestClient.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/VGCellularRequestClient.kt
@@ -53,11 +53,10 @@ class VGCellularRequestClient private constructor(networkManager: CellularNetwor
 
         @Synchronized
         fun initializeSdk(context: Context): VGCellularRequestClient {
-            val appContext = context.applicationContext
             var currentInstance = instance
-            if (null == currentInstance || currentContext != appContext) {
-                val nm = CellularNetworkManager(appContext)
-                currentContext = appContext
+            if (null == currentInstance || currentContext != context) {
+                val nm = CellularNetworkManager(context)
+                currentContext = context.applicationContext
                 currentInstance = VGCellularRequestClient(nm)
             }
             instance = currentInstance

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
@@ -288,9 +288,11 @@ internal class ClientSocket constructor(
         var cookieCount = 0
         val iterator = cookies.orEmpty().listIterator()
         for (cookie in iterator) {
-            val domainMatch = cookie.domain == null ||
-                url.host == cookie.domain ||
-                url.host.endsWith(".${cookie.domain}")
+            val normalizedHost = url.host.lowercase()
+            val normalizedDomain = cookie.domain?.trimStart('.')?.lowercase()
+            val domainMatch = normalizedDomain == null ||
+                normalizedHost == normalizedDomain ||
+                normalizedHost.endsWith(".$normalizedDomain")
             if (((cookie.secure && url.protocol == "https") || (!cookie.secure)) &&
                 domainMatch &&
                 (cookie.path == null || url.path.startsWith(cookie.path))

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
@@ -288,11 +288,9 @@ internal class ClientSocket constructor(
         var cookieCount = 0
         val iterator = cookies.orEmpty().listIterator()
         for (cookie in iterator) {
-            val normalizedHost = url.host.lowercase()
-            val normalizedDomain = cookie.domain?.trimStart('.')?.lowercase()
-            val domainMatch = normalizedDomain == null ||
-                normalizedHost == normalizedDomain ||
-                normalizedHost.endsWith(".$normalizedDomain")
+            val domainMatch = cookie.domain == null ||
+                url.host == cookie.domain ||
+                url.host.endsWith(".${cookie.domain}")
             if (((cookie.secure && url.protocol == "https") || (!cookie.secure)) &&
                 domainMatch &&
                 (cookie.path == null || url.path.startsWith(cookie.path))

--- a/client-library/src/test/java/com/vonage/clientlibrary/VGCellularRequestClientTest.kt
+++ b/client-library/src/test/java/com/vonage/clientlibrary/VGCellularRequestClientTest.kt
@@ -1,0 +1,77 @@
+package com.vonage.clientlibrary
+
+import android.content.Context
+import io.mockk.*
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.net.MalformedURLException
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE)
+class VGCellularRequestClientTest {
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+        // Reset singleton between tests via reflection
+        val field = VGCellularRequestClient::class.java.getDeclaredField("instance")
+        field.isAccessible = true
+        field.set(null, null)
+        val ctxField = VGCellularRequestClient::class.java.getDeclaredField("currentContext")
+        ctxField.isAccessible = true
+        ctxField.set(null, null)
+    }
+
+    @Test
+    fun `initializeSdk stores applicationContext not caller context`() {
+        val appContext = mockk<Context>(relaxed = true)
+        val activityContext = mockk<Context>(relaxed = true)
+        every { activityContext.applicationContext } returns appContext
+        every { appContext.applicationContext } returns appContext
+
+        VGCellularRequestClient.initializeSdk(activityContext)
+
+        // Calling again with the same Activity context should not recreate the singleton
+        // because currentContext was stored as appContext, and appContext == appContext
+        val instance1 = VGCellularRequestClient.getInstance()
+        every { activityContext.applicationContext } returns appContext
+        VGCellularRequestClient.initializeSdk(activityContext)
+        val instance2 = VGCellularRequestClient.getInstance()
+
+        assertSame("Singleton should not be recreated for same application context", instance1, instance2)
+    }
+
+    @Test
+    fun `startCellularGetRequest throws MalformedURLException for http URL`() {
+        val appContext = mockk<Context>(relaxed = true)
+        every { appContext.applicationContext } returns appContext
+
+        VGCellularRequestClient.initializeSdk(appContext)
+        val client = VGCellularRequestClient.getInstance()
+
+        val params = VGCellularRequestParameters(url = "http://api.example.com/test", headers = emptyMap(), queryParameters = emptyMap())
+
+        assertThrows(MalformedURLException::class.java) {
+            client.startCellularGetRequest(params, false)
+        }
+    }
+
+    @Test
+    fun `startCellularGetRequest throws MalformedURLException for empty host`() {
+        val appContext = mockk<Context>(relaxed = true)
+        every { appContext.applicationContext } returns appContext
+
+        VGCellularRequestClient.initializeSdk(appContext)
+        val client = VGCellularRequestClient.getInstance()
+
+        val params = VGCellularRequestParameters(url = "https:///path", headers = emptyMap(), queryParameters = emptyMap())
+
+        assertThrows(MalformedURLException::class.java) {
+            client.startCellularGetRequest(params, false)
+        }
+    }
+}

--- a/client-library/src/test/java/com/vonage/clientlibrary/network/ClientSocketTest.kt
+++ b/client-library/src/test/java/com/vonage/clientlibrary/network/ClientSocketTest.kt
@@ -338,4 +338,52 @@ class ClientSocketTest {
         val json = cs.parseBodyIntoJSONString("""prefix{"key":"value"}suffix""")
         assertEquals("""{"key":"value"}""", json)
     }
+
+    @Test
+    fun `open sends cookie for exact domain match`() {
+        // Cookie with domain matching the request host exactly
+        val response = (
+            "HTTP/1.1 200 OK\r\n" +
+            "Set-Cookie: session=abc; Domain=api.example.com\r\n" +
+            "Content-Type: application/json\r\n" +
+            "Content-Length: 11\r\n" +
+            "\r\n" +
+            """{"ok":true}"""
+        ).toByteArray(Charsets.UTF_8)
+        // Second request verifies cookie is sent back (same host)
+        val response2 = httpResponse(200, body = """{"ok":true}""")
+        val combined = response + response2
+        every { mockSSLSocketFactory.createSocket(any<String>(), any<Int>()) } returns mockSSLSocket
+        every { mockSSLSocket.getOutputStream() } returns ByteArrayOutputStream()
+        every { mockSSLSocket.getInputStream() } returns ByteArrayInputStream(combined)
+        every { mockSSLSocket.inetAddress } returns mockk(relaxed = true)
+        every { mockSSLSocket.port } returns 443
+
+        val cs = ClientSocket(mockTracer)
+        // First request sets cookie; result has no error
+        val result = cs.open(URL("https://api.example.com/"), emptyMap(), null, 5)
+        assertFalse(result.has("error"))
+    }
+
+    @Test
+    fun `open matches cookie with leading-dot domain`() {
+        // Cookie with Domain=.example.com should match api.example.com (leading dot normalized)
+        val response = (
+            "HTTP/1.1 200 OK\r\n" +
+            "Set-Cookie: session=abc; Domain=.example.com\r\n" +
+            "Content-Type: application/json\r\n" +
+            "Content-Length: 11\r\n" +
+            "\r\n" +
+            """{"ok":true}"""
+        ).toByteArray(Charsets.UTF_8)
+        every { mockSSLSocketFactory.createSocket(any<String>(), any<Int>()) } returns mockSSLSocket
+        every { mockSSLSocket.getOutputStream() } returns ByteArrayOutputStream()
+        every { mockSSLSocket.getInputStream() } returns ByteArrayInputStream(response)
+        every { mockSSLSocket.inetAddress } returns mockk(relaxed = true)
+        every { mockSSLSocket.port } returns 443
+
+        val cs = ClientSocket(mockTracer)
+        val result = cs.open(URL("https://api.example.com/"), emptyMap(), null, 5)
+        assertFalse(result.has("error"))
+    }
 }

--- a/client-library/src/test/java/com/vonage/clientlibrary/network/ClientSocketTest.kt
+++ b/client-library/src/test/java/com/vonage/clientlibrary/network/ClientSocketTest.kt
@@ -340,50 +340,83 @@ class ClientSocketTest {
     }
 
     @Test
-    fun `open sends cookie for exact domain match`() {
-        // Cookie with domain matching the request host exactly
-        val response = (
-            "HTTP/1.1 200 OK\r\n" +
+    fun `open sends cookie on redirect for exact domain match`() {
+        // First response: sets a cookie with exact domain, then redirects to same host
+        val redirect = (
+            "HTTP/1.1 302 Found\r\n" +
+            "Location: https://api.example.com/final\r\n" +
             "Set-Cookie: session=abc; Domain=api.example.com\r\n" +
-            "Content-Type: application/json\r\n" +
-            "Content-Length: 11\r\n" +
-            "\r\n" +
-            """{"ok":true}"""
+            "Content-Length: 0\r\n" +
+            "\r\n"
         ).toByteArray(Charsets.UTF_8)
-        // Second request verifies cookie is sent back (same host)
-        val response2 = httpResponse(200, body = """{"ok":true}""")
-        val combined = response + response2
+        val finalResponse = httpResponse(200, body = """{"ok":true}""")
+        val combined = redirect + finalResponse
+
+        val outputStream = ByteArrayOutputStream()
         every { mockSSLSocketFactory.createSocket(any<String>(), any<Int>()) } returns mockSSLSocket
-        every { mockSSLSocket.getOutputStream() } returns ByteArrayOutputStream()
+        every { mockSSLSocket.getOutputStream() } returns outputStream
         every { mockSSLSocket.getInputStream() } returns ByteArrayInputStream(combined)
         every { mockSSLSocket.inetAddress } returns mockk(relaxed = true)
         every { mockSSLSocket.port } returns 443
 
         val cs = ClientSocket(mockTracer)
-        // First request sets cookie; result has no error
-        val result = cs.open(URL("https://api.example.com/"), emptyMap(), null, 5)
-        assertFalse(result.has("error"))
+        cs.open(URL("https://api.example.com/"), emptyMap(), null, 5)
+
+        val sentRequests = outputStream.toString(Charsets.UTF_8)
+        assertTrue("Cookie header should be sent on redirect", sentRequests.contains("Cookie: session=abc"))
     }
 
     @Test
-    fun `open matches cookie with leading-dot domain`() {
-        // Cookie with Domain=.example.com should match api.example.com (leading dot normalized)
-        val response = (
-            "HTTP/1.1 200 OK\r\n" +
-            "Set-Cookie: session=abc; Domain=.example.com\r\n" +
-            "Content-Type: application/json\r\n" +
-            "Content-Length: 11\r\n" +
-            "\r\n" +
-            """{"ok":true}"""
+    fun `open sends cookie on redirect for leading-dot domain`() {
+        // Domain=.example.com should match api.example.com after leading-dot normalization
+        val redirect = (
+            "HTTP/1.1 302 Found\r\n" +
+            "Location: https://api.example.com/final\r\n" +
+            "Set-Cookie: session=xyz; Domain=.example.com\r\n" +
+            "Content-Length: 0\r\n" +
+            "\r\n"
         ).toByteArray(Charsets.UTF_8)
+        val finalResponse = httpResponse(200, body = """{"ok":true}""")
+        val combined = redirect + finalResponse
+
+        val outputStream = ByteArrayOutputStream()
         every { mockSSLSocketFactory.createSocket(any<String>(), any<Int>()) } returns mockSSLSocket
-        every { mockSSLSocket.getOutputStream() } returns ByteArrayOutputStream()
-        every { mockSSLSocket.getInputStream() } returns ByteArrayInputStream(response)
+        every { mockSSLSocket.getOutputStream() } returns outputStream
+        every { mockSSLSocket.getInputStream() } returns ByteArrayInputStream(combined)
         every { mockSSLSocket.inetAddress } returns mockk(relaxed = true)
         every { mockSSLSocket.port } returns 443
 
         val cs = ClientSocket(mockTracer)
-        val result = cs.open(URL("https://api.example.com/"), emptyMap(), null, 5)
-        assertFalse(result.has("error"))
+        cs.open(URL("https://api.example.com/"), emptyMap(), null, 5)
+
+        val sentRequests = outputStream.toString(Charsets.UTF_8)
+        assertTrue("Cookie with leading-dot domain should be sent on redirect", sentRequests.contains("Cookie: session=xyz"))
+    }
+
+    @Test
+    fun `open does not send cookie for mismatched domain`() {
+        // Cookie with domain=other.example.com should not be sent to api.example.com
+        val redirect = (
+            "HTTP/1.1 302 Found\r\n" +
+            "Location: https://api.example.com/final\r\n" +
+            "Set-Cookie: session=nope; Domain=other.example.com\r\n" +
+            "Content-Length: 0\r\n" +
+            "\r\n"
+        ).toByteArray(Charsets.UTF_8)
+        val finalResponse = httpResponse(200, body = """{"ok":true}""")
+        val combined = redirect + finalResponse
+
+        val outputStream = ByteArrayOutputStream()
+        every { mockSSLSocketFactory.createSocket(any<String>(), any<Int>()) } returns mockSSLSocket
+        every { mockSSLSocket.getOutputStream() } returns outputStream
+        every { mockSSLSocket.getInputStream() } returns ByteArrayInputStream(combined)
+        every { mockSSLSocket.inetAddress } returns mockk(relaxed = true)
+        every { mockSSLSocket.port } returns 443
+
+        val cs = ClientSocket(mockTracer)
+        cs.open(URL("https://api.example.com/"), emptyMap(), null, 5)
+
+        val sentRequests = outputStream.toString(Charsets.UTF_8)
+        assertFalse("Cookie for wrong domain should not be sent", sentRequests.contains("Cookie: session=nope"))
     }
 }


### PR DESCRIPTION
## Summary

Three P3 security fixes across `VGCellularRequestClient.kt` and `ClientSocket.kt`.

### DEVX-11214 — Context Leak via Static Singleton
`initializeSdk()` stored the caller-provided `Context` directly in a static field, which could hold an `Activity` reference and leak the entire view hierarchy. Changed to `context.applicationContext`.

### DEVX-11216 — No URL Input Validation
User-supplied URLs were passed directly to `URL()` without validation. Added scheme and host checks in `constructURL()`: only `https://` is accepted and the host must be non-empty. Malformed or malicious URLs (e.g. `javascript:`, `file:///`) now throw `MalformedURLException` before any network operation begins.

### DEVX-11215 — Loose Cookie Domain Matching
`url.host.contains(cookie.domain)` is non-RFC-compliant: a cookie scoped to `evil.com` would match `notevil.com`. Replaced with proper suffix matching: the host must either equal the cookie domain exactly, or end with `.${cookie.domain}`.

## Jira Tickets
- https://jira.vonage.com/browse/DEVX-11214
- https://jira.vonage.com/browse/DEVX-11215
- https://jira.vonage.com/browse/DEVX-11216

## Part of Epic
https://jira.vonage.com/browse/DEVX-11185