### PR TITLE
DEVX-11224: Skip requestNetwork() when cellular is already active

### DIFF
--- a/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
@@ -110,6 +110,15 @@ internal class CellularNetworkManager(context: Context) : NetworkManager {
     }
 
     private fun execute(onCompletion: (isSuccess: Boolean) -> Unit) {
+        // DEVX-11224: Fast-path — if cellular is already available and bound to the
+        // process, skip the expensive requestNetwork() flow (which can wait up to 5s
+        // for network acquisition even when cellular is already active).
+        if (isCellularAvailable() && isCellularBoundToProcess()) {
+            tracer.addDebug(Log.DEBUG, TAG, "Fast-path: cellular already available and bound")
+            onCompletion(true)
+            return
+        }
+
         try {
             val lock = ReentrantLock()
             val condition = lock.newCondition()

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
@@ -110,11 +110,14 @@ internal class CellularNetworkManager(context: Context) : NetworkManager {
     }
 
     private fun execute(onCompletion: (isSuccess: Boolean) -> Unit) {
-        // DEVX-11224: Fast-path — if cellular is already available and bound to the
-        // process, skip the expensive requestNetwork() flow (which can wait up to 5s
-        // for network acquisition even when cellular is already active).
-        if (isCellularAvailable() && isCellularBoundToProcess()) {
-            tracer.addDebug(Log.DEBUG, TAG, "Fast-path: cellular already available and bound")
+        // DEVX-11224: Fast-path — skip the expensive requestNetwork() flow (which can wait
+        // up to 5s) if cellular is already the active network, or is available and bound to
+        // the process. The active-network check is the primary trigger for successive requests:
+        // forceCellular() always calls bind(null) in its finally block, so isCellularBoundToProcess()
+        // won't be true after a prior call, but isCellularActiveNetwork() will still be true if
+        // cellular remains the active network.
+        if (isCellularActiveNetwork() || (isCellularAvailable() && isCellularBoundToProcess())) {
+            tracer.addDebug(Log.DEBUG, TAG, "Fast-path: cellular already active or available and bound")
             onCompletion(true)
             return
         }
@@ -352,6 +355,11 @@ internal class CellularNetworkManager(context: Context) : NetworkManager {
             }
         }
         return false
+    }
+
+    // minSdk = 24 >= M (23), so activeNetwork is always available — no API guard needed.
+    private fun isCellularActiveNetwork(): Boolean {
+        return connectivityManager.activeNetwork?.let { isCellular(it) } ?: false
     }
 
     companion object {


### PR DESCRIPTION
## Summary

The `execute()` method always went through the full `forceCellular()` → `requestNetwork()` flow even when the device already had cellular data active and bound. In the common case (successive requests, cellular already up), this added unnecessary overhead including a potential 5-second wait.

### Change
Added a fast-path at the start of `execute()`: if `isCellularAvailable()` and `isCellularBoundToProcess()` are both true, `onCompletion(true)` is called immediately and returns — bypassing `requestNetwork()` entirely.

The slow-path (full network acquisition) is preserved as a fallback for when cellular is not yet active or not bound to the process.

> **Note:** This PR has a minor conflict with DEVX-11220 (deadlock fix) on the same method. Merge DEVX-11220 first, then this one.

## Jira Ticket
https://jira.vonage.com/browse/DEVX-11224

## Part of Epic
https://jira.vonage.com/browse/DEVX-11185