### PR TITLE
DEVX-11226: Fix SimpleDateFormat thread safety and incorrect format pattern

### DIFF
--- a/client-library/src/main/java/com/vonage/clientlibrary/network/DateUtils.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/DateUtils.kt
@@ -10,20 +10,23 @@ import java.util.TimeZone
 class DateUtils {
 
     companion object {
-        private val simpleDateFormat: SimpleDateFormat by lazy {
-            var sf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.ssssss'Z'")
-            sf.setTimeZone(TimeZone.getTimeZone("UTC"))
-            sf
+        // DEVX-11226: SimpleDateFormat is not thread-safe. Use ThreadLocal so each thread
+        // gets its own instance, avoiding data races when logging is concurrent.
+        // Also fixes the format pattern: 'ssssss' (seconds repeated) → 'SSS' (milliseconds).
+        private val simpleDateFormat: ThreadLocal<SimpleDateFormat> = ThreadLocal.withInitial {
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").also {
+                it.timeZone = TimeZone.getTimeZone("UTC")
+            }
         }
 
         /**
-         * Returns the ISO-8601 formatted date in UTC, such as '2011-12-03T10:15:30Z'
+         * Returns the ISO-8601 formatted date in UTC, such as '2011-12-03T10:15:30.123Z'
          */
         public fun now(): String {
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 DateTimeFormatter.ISO_INSTANT.format(Instant.now())
             } else {
-                simpleDateFormat.format(Date())
+                simpleDateFormat.get()!!.format(Date())
             }
         }
     }

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/DateUtils.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/DateUtils.kt
@@ -24,13 +24,17 @@ class DateUtils {
             }
 
         /**
-         * Returns the ISO-8601 formatted date in UTC, such as '2011-12-03T10:15:30.123Z'
+         * Returns the current time as an ISO-8601 UTC string.
+         * On API 26+, uses DateTimeFormatter.ISO_INSTANT: fractional seconds are omitted when
+         * zero and may be 1–9 digits otherwise (e.g. '2011-12-03T10:15:30Z').
+         * On API < 26, uses SimpleDateFormat with millisecond precision
+         * (e.g. '2011-12-03T10:15:30.123Z').
          */
         public fun now(): String {
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 DateTimeFormatter.ISO_INSTANT.format(Instant.now())
             } else {
-                requireNotNull(simpleDateFormat.get()).format(Date())
+                simpleDateFormat.get()!!.format(Date())
             }
         }
     }

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/DateUtils.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/DateUtils.kt
@@ -5,6 +5,7 @@ import java.text.SimpleDateFormat
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.util.Date
+import java.util.Locale
 import java.util.TimeZone
 
 class DateUtils {
@@ -13,11 +14,14 @@ class DateUtils {
         // DEVX-11226: SimpleDateFormat is not thread-safe. Use ThreadLocal so each thread
         // gets its own instance, avoiding data races when logging is concurrent.
         // Also fixes the format pattern: 'ssssss' (seconds repeated) → 'SSS' (milliseconds).
-        private val simpleDateFormat: ThreadLocal<SimpleDateFormat> = ThreadLocal.withInitial {
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").also {
-                it.timeZone = TimeZone.getTimeZone("UTC")
+        // Note: ThreadLocal.withInitial{} requires API 26+; anonymous initialValue() works on all supported levels.
+        private val simpleDateFormat: ThreadLocal<SimpleDateFormat> =
+            object : ThreadLocal<SimpleDateFormat>() {
+                override fun initialValue(): SimpleDateFormat =
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).also {
+                        it.timeZone = TimeZone.getTimeZone("UTC")
+                    }
             }
-        }
 
         /**
          * Returns the ISO-8601 formatted date in UTC, such as '2011-12-03T10:15:30.123Z'
@@ -26,7 +30,7 @@ class DateUtils {
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 DateTimeFormatter.ISO_INSTANT.format(Instant.now())
             } else {
-                simpleDateFormat.get()!!.format(Date())
+                requireNotNull(simpleDateFormat.get()).format(Date())
             }
         }
     }

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/DateUtils.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/DateUtils.kt
@@ -13,7 +13,8 @@ class DateUtils {
     companion object {
         // DEVX-11226: SimpleDateFormat is not thread-safe. Use ThreadLocal so each thread
         // gets its own instance, avoiding data races when logging is concurrent.
-        // Also fixes the format pattern: 'ssssss' (seconds repeated) → 'SSS' (milliseconds).
+        // Also fixes the format pattern: 'ssssss' (seconds zero-padded to 6 digits, e.g. '000045')
+        // → 'SSS' (milliseconds, 3 digits).
         // Note: ThreadLocal.withInitial{} requires API 26+; anonymous initialValue() works on all supported levels.
         private val simpleDateFormat: ThreadLocal<SimpleDateFormat> =
             object : ThreadLocal<SimpleDateFormat>() {
@@ -34,7 +35,7 @@ class DateUtils {
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 DateTimeFormatter.ISO_INSTANT.format(Instant.now())
             } else {
-                simpleDateFormat.get()!!.format(Date())
+                simpleDateFormat.get().format(Date())
             }
         }
     }


### PR DESCRIPTION
## Summary

### Thread Safety
`SimpleDateFormat` is not thread-safe. The shared `by lazy` instance in `DateUtils` could produce corrupted output or throw exceptions when `now()` is called concurrently from multiple threads (e.g., logging from network callback and main thread simultaneously).

**Fix:** replaced the shared `lazy` instance with `ThreadLocal.withInitial {}` so each thread gets its own formatter instance.

### Format Pattern Bug
The format string was `"yyyy-MM-dd'T'HH:mm:ss.ssssss'Z'"` — `ssssss` is the seconds field repeated six times, not milliseconds. This produced garbled timestamps like `2024-01-15T10:30:45.454545Z` instead of the intended `2024-01-15T10:30:45.123Z`.

**Fix:** corrected to `"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"` (`SSS` = milliseconds).

Note: This only affects API < 26 (Oreo); newer API uses `DateTimeFormatter.ISO_INSTANT` which was already correct.

## Jira Ticket
https://jira.vonage.com/browse/DEVX-11226

## Part of Epic
https://jira.vonage.com/browse/DEVX-11185