### PR TITLE
DEVX-11217: Document isEmulator() as best-effort hint, not a security control

### DIFF
--- a/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
@@ -429,6 +429,15 @@ internal class ClientSocket constructor(var tracer: TraceCollector = TraceCollec
         }
     }
 
+    /**
+     * Returns a best-effort guess of whether the app is running on an emulator, based on
+     * easily-spoofed [Build] properties.
+     *
+     * **This is NOT a security control.** A determined attacker can trivially set any of these
+     * build properties to bypass this check. Its sole purpose is a convenience hint for
+     * sandbox/debug routing (the `x-silentauth-mode: sandbox` header). Do not rely on it
+     * to restrict access, enforce licensing, or make any trust decision.
+     */
     private fun isEmulator(): Boolean {
         return Build.FINGERPRINT.contains("generic") ||
                 Build.FINGERPRINT.startsWith("unknown") ||


### PR DESCRIPTION
## Summary

`isEmulator()` relied on `Build` properties that can be trivially set by any attacker. The method was being used as a routing hint (`x-silentauth-mode: sandbox`), which is fine, but there was no documentation clarifying its limitations.

Added KDoc explicitly stating:
- This is a **best-effort convenience hint** only
- Build properties are easily spoofable
- Must **not** be used as a security boundary, license gate, or trust decision

No functional change.

## Jira Ticket
https://jira.vonage.com/browse/DEVX-11217

## Part of Epic
https://jira.vonage.com/browse/DEVX-11185