### PR TITLE
DEVX-11218: Remove unused okhttp and logging-interceptor dependencies

### DIFF
--- a/client-library/build.gradle.kts
+++ b/client-library/build.gradle.kts
@@ -107,8 +107,6 @@ dependencies {
     implementation (libs.androidx.appcompat)
     implementation (libs.kotlin.stdlib)
     implementation (libs.androidx.core.ktx)
-    implementation (libs.okhttp)
-    implementation (libs.logging.interceptor)
 }
 java {
     toolchain {


### PR DESCRIPTION
## Summary

`okhttp` and `logging-interceptor` are declared in `client-library/build.gradle.kts` but are not imported or used anywhere in the library source code.

Removing them:
- Reduces APK size
- Eliminates unnecessary transitive dependencies
- Shrinks the attack surface (fewer third-party libs that could carry CVEs)

## Jira Ticket
https://jira.vonage.com/browse/DEVX-11218

## Part of Epic
https://jira.vonage.com/browse/DEVX-11185