### PR TITLE
DEVX-10955: Log operator-injected tracking headers in Silent Auth responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/*.gradle.kts', '**/libs.versions.toml', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-
+
+      - name: Run unit tests
+        run: ./gradlew :client-library:test
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: client-library/build/reports/tests/

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
@@ -74,6 +74,12 @@ internal class CellularNetworkManager(context: Context) : NetworkManager {
                     val json = JSONObject()
                     json.put("device_info", deviceInfo())
                     json.put("url_trace", tracer.getTrace().trace)
+                    val tracking = cs.lastOperatorTrackingHeaders
+                    if (tracking.isNotEmpty()) {
+                        val trackingJson = JSONObject()
+                        tracking.forEach { (k, v) -> trackingJson.put(k, v) }
+                        json.put("operator_tracking", trackingJson)
+                    }
                     response.put("debug", json)
                     tracer.stopTrace()
                 }

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/ClientSocket.kt
@@ -24,6 +24,9 @@ internal class ClientSocket constructor(
     private lateinit var output: OutputStream
     private lateinit var rawInput: InputStream  // kept raw for byte-accurate Content-Length reads
 
+    var lastOperatorTrackingHeaders: Map<String, String> = emptyMap()
+        private set
+
     fun open(
         url: URL,
         headers: Map<String, String>?,
@@ -396,6 +399,7 @@ internal class ClientSocket constructor(
         val bodyBuilder = StringBuilder()  // DEVX-11223: avoid O(n²) string concat
         val cookies: ArrayList<HttpCookie> = ArrayList()
         if (existingCookies != null) cookies.addAll(existingCookies)
+        val trackingHeaders: MutableMap<String, String> = mutableMapOf()
 
         try {
             // DEVX-11221: Parse headers line-by-line instead of buffering the full response.
@@ -447,6 +451,16 @@ internal class ClientSocket constructor(
                             if (isDebuggable) tracer.addDebug(Log.DEBUG, TAG, "Content-Length - $contentLength")
                         }
                     }
+                    OPERATOR_TRACKING_HEADERS.any { line!!.startsWith(it, ignoreCase = true) } -> {
+                        val currentLine = line!!
+                        val colonIdx = currentLine.indexOf(':')
+                        if (colonIdx > 0) {
+                            val name = currentLine.substring(0, colonIdx).trim()
+                            val value = currentLine.substring(colonIdx + 1).trim()
+                            trackingHeaders[name] = value
+                            tracer.addDebug(Log.DEBUG, TAG, "Operator tracking header: $name=$value")
+                        }
+                    }
                     (type == "application/json" || type == "application/hal+json" || type == "application/problem+json") && line.isEmpty() -> {
                         bodyBegin = true
                     }
@@ -493,10 +507,11 @@ internal class ClientSocket constructor(
             val body: String? = if (bodyBegin && bodyBuilder.isNotEmpty()) bodyBuilder.toString() else null
             if (isDebuggable) tracer.addDebug(Log.DEBUG, TAG, "Status - $status\nBody - $body\n")
             tracer.addTrace("Status - $status ${DateUtils.now()}\nBody - $body\n")
+            lastOperatorTrackingHeaders = trackingHeaders
             return redirectResult ?: if (bodyBegin && body != null) {
-                ResultHandler(status, null, parseBodyIntoJSONString(body), cookies)
+                ResultHandler(status, null, parseBodyIntoJSONString(body), cookies, operatorTrackingHeaders = trackingHeaders)
             } else {
-                ResultHandler(status, null, null, null)
+                ResultHandler(status, null, null, null, operatorTrackingHeaders = trackingHeaders)
             }
         } catch (ex: Exception) {
             tracer.addDebug(Log.ERROR, TAG, "Client reading exception : ${ex.message}")
@@ -612,6 +627,13 @@ internal class ClientSocket constructor(
         private const val PORT_443 = 443
         private const val CRLF = "\r\n"
         private const val GLOBAL_DEADLINE_MS: Long = 30_000
+
+        // Operator-injected tracking headers to capture and log for troubleshooting.
+        // Orange uses X-Orange-Trace-Id; Vodafone uses X-VIG-Trace-Id.
+        internal val OPERATOR_TRACKING_HEADERS = listOf(
+            "X-Orange-Trace-Id",
+            "X-VIG-Trace-Id"
+        )
     }
 
     class ResultHandler(
@@ -619,7 +641,8 @@ internal class ClientSocket constructor(
         redirect: URL?,
         body: String?,
         cookies: ArrayList<HttpCookie>?,
-        val mustCloseConnection: Boolean = false
+        val mustCloseConnection: Boolean = false,
+        val operatorTrackingHeaders: Map<String, String> = emptyMap()
     ) : ResultResponse {
         val s: Int = httpStatus
         val r: URL? = redirect
@@ -643,7 +666,7 @@ internal class ClientSocket constructor(
         }
 
         fun withMustClose(): ResultHandler =
-            ResultHandler(s, r, b, cs, mustCloseConnection = true)
+            ResultHandler(s, r, b, cs, mustCloseConnection = true, operatorTrackingHeaders)
     }
 
     class ResponseHandler(httpStatus: Int, body: String?) : ResultResponse {

--- a/client-library/src/test/java/com/vonage/clientlibrary/network/ClientSocketTest.kt
+++ b/client-library/src/test/java/com/vonage/clientlibrary/network/ClientSocketTest.kt
@@ -419,4 +419,86 @@ class ClientSocketTest {
         val sentRequests = outputStream.toString(Charsets.UTF_8)
         assertFalse("Cookie for wrong domain should not be sent", sentRequests.contains("Cookie: session=nope"))
     }
+
+    // ------------------------------------------------------------------
+    // DEVX-10955: Operator tracking headers
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `open captures Orange trace ID header`() {
+        stubResponse(httpResponse(200,
+            headers = "X-Orange-Trace-Id: orange-abc-123\r\n",
+            body = """{"ok":true}"""
+        ))
+
+        val cs = ClientSocket(mockTracer)
+        cs.open(URL("https://api.example.com/"), emptyMap(), null, 5)
+
+        assertEquals("orange-abc-123", cs.lastOperatorTrackingHeaders["X-Orange-Trace-Id"])
+    }
+
+    @Test
+    fun `open captures Vodafone trace ID header`() {
+        stubResponse(httpResponse(200,
+            headers = "X-VIG-Trace-Id: vodafone-xyz-789\r\n",
+            body = """{"ok":true}"""
+        ))
+
+        val cs = ClientSocket(mockTracer)
+        cs.open(URL("https://api.example.com/"), emptyMap(), null, 5)
+
+        assertEquals("vodafone-xyz-789", cs.lastOperatorTrackingHeaders["X-VIG-Trace-Id"])
+    }
+
+    @Test
+    fun `open captures multiple operator tracking headers`() {
+        stubResponse(httpResponse(200,
+            headers = "X-Orange-Trace-Id: orange-111\r\nX-VIG-Trace-Id: voda-222\r\n",
+            body = """{"ok":true}"""
+        ))
+
+        val cs = ClientSocket(mockTracer)
+        cs.open(URL("https://api.example.com/"), emptyMap(), null, 5)
+
+        assertEquals("orange-111", cs.lastOperatorTrackingHeaders["X-Orange-Trace-Id"])
+        assertEquals("voda-222", cs.lastOperatorTrackingHeaders["X-VIG-Trace-Id"])
+    }
+
+    @Test
+    fun `open ignores non-tracking headers and does not include them in tracking map`() {
+        stubResponse(httpResponse(200,
+            headers = "X-Custom-Header: should-be-ignored\r\n",
+            body = """{"ok":true}"""
+        ))
+
+        val cs = ClientSocket(mockTracer)
+        cs.open(URL("https://api.example.com/"), emptyMap(), null, 5)
+
+        assertFalse(cs.lastOperatorTrackingHeaders.containsKey("X-Custom-Header"))
+    }
+
+    @Test
+    fun `lastOperatorTrackingHeaders is empty when no tracking headers present`() {
+        stubResponse(httpResponse(200, body = """{"ok":true}"""))
+
+        val cs = ClientSocket(mockTracer)
+        cs.open(URL("https://api.example.com/"), emptyMap(), null, 5)
+
+        assertTrue(cs.lastOperatorTrackingHeaders.isEmpty())
+    }
+
+    @Test
+    fun `operator tracking header matching is case-insensitive`() {
+        stubResponse(httpResponse(200,
+            headers = "x-orange-trace-id: lower-case-value\r\n",
+            body = """{"ok":true}"""
+        ))
+
+        val cs = ClientSocket(mockTracer)
+        cs.open(URL("https://api.example.com/"), emptyMap(), null, 5)
+
+        // The key is stored as it appears in the response, value should be captured
+        val keys = cs.lastOperatorTrackingHeaders.keys.map { it.lowercase() }
+        assertTrue(keys.contains("x-orange-trace-id"))
+    }
 }


### PR DESCRIPTION
## Summary

Captures operator-injected tracking headers from Silent Auth HTTP responses to simplify troubleshooting. Initially covers Vodafone (`X-VIG-Trace-Id`) and Orange (`X-Orange-Trace-Id`).

### Changes

- **ClientSocket**: Parses known operator tracking headers during response reading. Captured headers are stored on `lastOperatorTrackingHeaders` and on `ResultHandler`.
- **CellularNetworkManager**: When `debug=true`, includes an `operator_tracking` JSON object in the debug block if any tracking headers were present.
- **ClientSocketTest**: 6 new unit tests covering capture, case-insensitivity, multiple headers, and absence of headers.
- **CI**: Added GitHub Actions workflow to run unit tests on every push and PR.

### Debug response shape (when tracking headers are present)

```json
{
  "http_status": 200,
  "debug": {
    "device_info": "...",
    "url_trace": "...",
    "operator_tracking": {
      "X-Orange-Trace-Id": "abc123"
    }
  }
}
```

## Jira Ticket
https://jira.vonage.com/browse/DEVX-10955