### PR TITLE
DEVX-11183: Add getCellularStatus() pre-check for Silent Auth workflow selection

### DIFF
--- a/client-library/src/main/java/com/vonage/clientlibrary/CellularStatus.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/CellularStatus.kt
@@ -1,0 +1,47 @@
+package com.vonage.clientlibrary
+
+/**
+ * Represents the cellular connectivity status of the device.
+ *
+ * Use [VGCellularRequestClient.getCellularStatus] to retrieve the current status
+ * before initiating a Silent Authentication flow, so your app can select the
+ * appropriate Vonage Verify channel without waiting for a Silent Auth attempt to fail.
+ *
+ * Typical usage:
+ * ```kotlin
+ * when (VGCellularRequestClient.getInstance().getCellularStatus()) {
+ *     CellularStatus.Available -> {
+ *         // Cellular is the active network — proceed with Silent Auth
+ *     }
+ *     CellularStatus.AvailableNotActive -> {
+ *         // Cellular exists but device is on Wi-Fi — Silent Auth may still work
+ *         // but will take longer. Consider falling back to SMS/WhatsApp if latency matters.
+ *     }
+ *     CellularStatus.Unavailable -> {
+ *         // No cellular interface — skip Silent Auth and use another Verify channel
+ *     }
+ * }
+ * ```
+ */
+sealed class CellularStatus {
+
+    /**
+     * Cellular is the device's active network. Silent Authentication is very likely
+     * to succeed and should be attempted first.
+     */
+    object Available : CellularStatus()
+
+    /**
+     * A cellular interface exists on the device but is not the current active network
+     * (the device is likely on Wi-Fi). Silent Authentication may still succeed but
+     * will incur additional latency while the SDK forces a cellular connection.
+     * Consider your UX tolerance before proceeding.
+     */
+    object AvailableNotActive : CellularStatus()
+
+    /**
+     * No cellular interface was detected. Silent Authentication will not succeed.
+     * Fall back to another Vonage Verify channel (e.g. SMS or WhatsApp).
+     */
+    object Unavailable : CellularStatus()
+}

--- a/client-library/src/main/java/com/vonage/clientlibrary/VGCellularRequestClient.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/VGCellularRequestClient.kt
@@ -11,6 +11,22 @@ import java.net.URL
 class VGCellularRequestClient private constructor(networkManager: CellularNetworkManager) {
     private val networkManager: NetworkManager = networkManager
 
+    /**
+     * Returns the current cellular connectivity status of the device.
+     *
+     * Call this before initiating a Silent Authentication flow to determine whether
+     * cellular is available and select the appropriate Vonage Verify channel.
+     *
+     * This is a fast, synchronous check — it does not attempt a network connection.
+     *
+     * @return [CellularStatus.Available] if cellular is the active network,
+     *         [CellularStatus.AvailableNotActive] if a cellular interface exists but is not active,
+     *         [CellularStatus.Unavailable] if no cellular interface is detected.
+     */
+    fun getCellularStatus(): CellularStatus {
+        return networkManager.getCellularStatus()
+    }
+
     /* This method performs a GET request given a URL with cellular connectivity
     - Parameters:
       - params: Parameters to configure your GET request

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/CellularNetworkManager.kt
@@ -15,6 +15,7 @@ import android.os.Looper
 import android.telephony.TelephonyManager
 import android.util.Log
 import androidx.annotation.RequiresApi
+import com.vonage.clientlibrary.CellularStatus
 import java.net.URL
 import java.util.Timer
 import java.util.TimerTask
@@ -42,6 +43,14 @@ internal class CellularNetworkManager(context: Context) : NetworkManager {
     private var timeoutTask: TimerTask? = null
 
     private val tracer = TraceCollector.instance
+
+    override fun getCellularStatus(): CellularStatus {
+        return when {
+            isCellularActiveNetwork() -> CellularStatus.Available
+            isCellularAvailable() -> CellularStatus.AvailableNotActive
+            else -> CellularStatus.Unavailable
+        }
+    }
 
     override fun openWithDataCellular(url: URL, headers: Map<String, String>?, maxRedirectCount: Int, debug: Boolean): JSONObject {
         var calledOnCellularNetwork = false

--- a/client-library/src/main/java/com/vonage/clientlibrary/network/NetworkManager.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/network/NetworkManager.kt
@@ -1,9 +1,11 @@
 package com.vonage.clientlibrary.network
 
+import com.vonage.clientlibrary.CellularStatus
 import org.json.JSONObject
 import java.net.URL
 
 internal interface NetworkManager {
+    fun getCellularStatus(): CellularStatus
     fun openWithDataCellular(url: URL, headers: Map<String, String>?, maxRedirectCount: Int, debug: Boolean): JSONObject
     fun postWithDataCellular(url: URL, headers: Map<String, String>, body: String?): JSONObject
 }

--- a/client-library/src/test/java/com/vonage/clientlibrary/VGCellularRequestClientTest.kt
+++ b/client-library/src/test/java/com/vonage/clientlibrary/VGCellularRequestClientTest.kt
@@ -1,6 +1,7 @@
 package com.vonage.clientlibrary
 
 import android.content.Context
+import com.vonage.clientlibrary.network.NetworkManager
 import io.mockk.*
 import org.junit.After
 import org.junit.Assert.*
@@ -24,6 +25,20 @@ class VGCellularRequestClientTest {
         val ctxField = VGCellularRequestClient::class.java.getDeclaredField("currentContext")
         ctxField.isAccessible = true
         ctxField.set(null, null)
+    }
+
+    /** Injects a mock NetworkManager into the singleton instance via reflection. */
+    private fun injectMockNetworkManager(client: VGCellularRequestClient, mock: NetworkManager) {
+        val field = VGCellularRequestClient::class.java.getDeclaredField("networkManager")
+        field.isAccessible = true
+        field.set(client, mock)
+    }
+
+    private fun buildClient(): VGCellularRequestClient {
+        val appContext = mockk<Context>(relaxed = true)
+        every { appContext.applicationContext } returns appContext
+        VGCellularRequestClient.initializeSdk(appContext)
+        return VGCellularRequestClient.getInstance()
     }
 
     @Test
@@ -73,5 +88,51 @@ class VGCellularRequestClientTest {
         assertThrows(MalformedURLException::class.java) {
             client.startCellularGetRequest(params, false)
         }
+    }
+
+    // ------------------------------------------------------------------
+    // DEVX-11183: getCellularStatus()
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `getCellularStatus returns Available when NetworkManager returns Available`() {
+        val client = buildClient()
+        val mockNm = mockk<NetworkManager>(relaxed = true)
+        every { mockNm.getCellularStatus() } returns CellularStatus.Available
+        injectMockNetworkManager(client, mockNm)
+
+        assertEquals(CellularStatus.Available, client.getCellularStatus())
+    }
+
+    @Test
+    fun `getCellularStatus returns AvailableNotActive when NetworkManager returns AvailableNotActive`() {
+        val client = buildClient()
+        val mockNm = mockk<NetworkManager>(relaxed = true)
+        every { mockNm.getCellularStatus() } returns CellularStatus.AvailableNotActive
+        injectMockNetworkManager(client, mockNm)
+
+        assertEquals(CellularStatus.AvailableNotActive, client.getCellularStatus())
+    }
+
+    @Test
+    fun `getCellularStatus returns Unavailable when NetworkManager returns Unavailable`() {
+        val client = buildClient()
+        val mockNm = mockk<NetworkManager>(relaxed = true)
+        every { mockNm.getCellularStatus() } returns CellularStatus.Unavailable
+        injectMockNetworkManager(client, mockNm)
+
+        assertEquals(CellularStatus.Unavailable, client.getCellularStatus())
+    }
+
+    @Test
+    fun `getCellularStatus delegates to NetworkManager exactly once`() {
+        val client = buildClient()
+        val mockNm = mockk<NetworkManager>(relaxed = true)
+        every { mockNm.getCellularStatus() } returns CellularStatus.Available
+        injectMockNetworkManager(client, mockNm)
+
+        client.getCellularStatus()
+
+        verify(exactly = 1) { mockNm.getCellularStatus() }
     }
 }


### PR DESCRIPTION
## Summary

Adds a fast, synchronous `getCellularStatus()` method to `VGCellularRequestClient` so apps can check cellular connectivity before deciding on a Vonage Verify channel, avoiding unnecessary Silent Auth attempts on devices with no cellular interface.

### New API

```kotlin
when (VGCellularRequestClient.getInstance().getCellularStatus()) {
    CellularStatus.Available -> {
        // Cellular is the active network — proceed with Silent Auth
    }
    CellularStatus.AvailableNotActive -> {
        // Cellular exists but device is on Wi-Fi — Silent Auth may work but will be slower
    }
    CellularStatus.Unavailable -> {
        // No cellular interface — fall back to SMS or WhatsApp
    }
}
```

### Changes

- **CellularStatus.kt**: New sealed class with three states: `Available`, `AvailableNotActive`, `Unavailable`
- **VGCellularRequestClient**: Exposes `getCellularStatus()` as a public method
- **CellularNetworkManager**: Implements `getCellularStatus()` using existing private connectivity checks — no new Android API calls
- **NetworkManager**: Interface updated to include `getCellularStatus()` for mockability
- **VGCellularRequestClientTest**: 4 new unit tests covering all three states and delegation behaviour

### Notes

- Synchronous and cheap — no `requestNetwork()` call, no blocking
- Reuses `isCellularActiveNetwork()` and `isCellularAvailable()` already present in `CellularNetworkManager`
- No new permissions required

## Jira Ticket
https://jira.vonage.com/browse/DEVX-11183