### PR TITLE
docs: Update README for 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,43 @@
 A library to support using the Vonage APIs on Android. Features:
 
 * Force a cellular network request for use with [Vonage Number Verification](https://developer.vonage.com/en/number-verification/overview) and [Vonage Verify Silent Authentication](https://developer.vonage.com/en/verify/guides/silent-authentication)
+* Check cellular connectivity status before initiating a Silent Authentication flow
 
 ## Installation
 
 build.gradle -> dependencies add
 
 ```
-implementation 'com.vonage:client-library:1.0.1'
+implementation 'com.vonage:client-library:1.1.0'
 ```
 
 ## Usage
+
+### Check Cellular Connectivity
+
+Before initiating a Silent Authentication flow, you can check whether the device has cellular connectivity to determine the appropriate Vonage Verify channel. This is a fast, synchronous check — it does not attempt a network connection.
+
+```kotlin
+import com.vonage.clientlibrary.VGCellularRequestClient
+import com.vonage.clientlibrary.CellularStatus
+
+VGCellularRequestClient.initializeSdk(this.applicationContext)
+
+when (VGCellularRequestClient.getInstance().getCellularStatus()) {
+    CellularStatus.Available -> {
+        // Cellular is the active network — proceed with Silent Auth
+    }
+    CellularStatus.AvailableNotActive -> {
+        // A cellular interface exists but the device is on Wi-Fi.
+        // Silent Auth may still work but will take longer.
+        // Consider falling back to SMS or WhatsApp if latency matters.
+    }
+    CellularStatus.Unavailable -> {
+        // No cellular interface detected — skip Silent Auth and use
+        // another Vonage Verify channel (e.g. SMS or WhatsApp)
+    }
+}
+```
 
 ### Force a Cellular Network Request
 
@@ -22,20 +49,20 @@ import com.vonage.clientlibrary.VGCellularRequestParameters
 
 VGCellularRequestClient.initializeSdk(this.applicationContext)
 
-val params = VGCellularRequestClientParameters(
+val params = VGCellularRequestParameters(
     url = "https://www.vonage.com",
-    headers = mapOf("x-my-header" to "My Value") ,
+    headers = mapOf("x-my-header" to "My Value"),
     queryParameters = mapOf("query-param" to "value"),
     maxRedirectCount = 10
 )
 
 val response = VGCellularRequestClient.getInstance().startCellularGetRequest(params, false)
-if (response.optString("error") != "") {
+if (response.has("error")) {
     // error
 } else {
     val status = response.optInt("http_status")
-    val jsonReponse = response.getJSONObject("response_body") // Body of response parsed to JSON (NULL if not JSON)
-    val rawReponse = response.optString("response_raw_body") // RAW string of response body (Only populated if not JSON)
+    val jsonResponse = response.optJSONObject("response_body") // Body of response parsed to JSON (NULL if not JSON)
+    val rawResponse = response.optString("response_raw_body") // RAW string of response body (Only populated if not JSON)
     if (status == 200) {
         // 200 OK
     } else {
@@ -43,38 +70,47 @@ if (response.optString("error") != "") {
     }
 }
 ```
-* `maxRedirectCount` in `VGCellularRequestParameters` is an optional and defaults to 10.
-* `debug` parameter for `startCellularRequest` is optional and defaults to false.
+
+* `maxRedirectCount` in `VGCellularRequestParameters` is optional and defaults to 10.
+* `debug` parameter for `startCellularGetRequest` is optional and defaults to false.
 * Only `https://` URLs are accepted. Passing an `http://` URL will throw a `MalformedURLException`.
 
 #### Responses
 
 * Success - When the data connectivity has been achieved, and a response has been received from the url endpoint:
-```
+```json
 {
-    "http_status": string, // HTTP status related to the url
-    "response_body" : { // Optional depending on the HTTP status
-        ... // The response body of the opened url
+    "http_status": 200,
+    "response_body": {
+        "...": "..."
     },
-    "debug" : {
-        "device_info": string, 
-        "url_trace" : string
+    "debug": {
+        "device_info": "string",
+        "url_trace": "string",
+        "operator_tracking": {
+            "X-Orange-Trace-Id": "string"
+        }
     }
 }
 ```
 
 * Error - When data connectivity is not available and/or an internal SDK error occurred:
 
-```
+```json
 {
-    "error" : string,
-    "error_description": string,
-    "debug" : {
-        "device_info": string, 
-        "url_trace" : string
+    "error": "string",
+    "error_description": "string",
+    "debug": {
+        "device_info": "string",
+        "url_trace": "string",
+        "operator_tracking": {
+            "X-Orange-Trace-Id": "string"
+        }
     }
 }
 ```
+
+`operator_tracking` is only present in the `debug` block when `debug = true` and the operator returned tracking headers in the response. Currently captured headers: `X-Orange-Trace-Id` (Orange), `X-VIG-Trace-Id` (Vodafone).
 
 Potential error codes: `sdk_no_data_connectivity`, `sdk_connection_error`, `sdk_redirect_error`, `sdk_error`.
 
@@ -86,13 +122,11 @@ If you need to inspect SDK network activity during development, build and run yo
 
 ## Migrating from `com.vonage:client-sdk-silent-auth` or `com.vonage:client-sdk-number-verification`
 
-`com.vonage:client-library` replaces both `com.vonage:client-sdk-silent-auth` and `com.vonage:client-sdk-number-verification`
-. To migrate from them do the following:
+`com.vonage:client-library` replaces both `com.vonage:client-sdk-silent-auth` and `com.vonage:client-sdk-number-verification`. To migrate from them do the following:
 
 ### Update your Dependencies:
 
-You will need to add `com.vonage:client-library` as a [dependency](#installation) and remove either `com.vonage:client-sdk-silent-auth` or `com.vonage:client-sdk-number-verification`
- depending on which one you were using. 
+You will need to add `com.vonage:client-library` as a [dependency](#installation) and remove either `com.vonage:client-sdk-silent-auth` or `com.vonage:client-sdk-number-verification` depending on which one you were using.
 
 ### Update the Imports:
 
@@ -136,7 +170,7 @@ VGCellularRequestClient.initializeSdk(this.applicationContext)
 
 ### Make the new Network Call:
 
-`com.vonage:client-library` uses a params object to pass information to the function that makes the network call. This is a similar approach to `om.vonage:client-sdk-number-verification`, but new if you are using `com.vonage:client-sdk-silent-auth`.
+`com.vonage:client-library` uses a params object to pass information to the function that makes the network call. This is a similar approach to `com.vonage:client-sdk-number-verification`, but new if you are using `com.vonage:client-sdk-silent-auth`.
 
 ```kotlin
 // com.vonage:client-sdk-silent-auth
@@ -148,13 +182,13 @@ or
 ```kotlin
 // com.vonage:client-sdk-number-verification
 val params = VGNumberVerificationParameters(
-        url = "https://www.vonage.com",
-        headers = mapOf("x-my-header" to "My Value") ,
-        queryParameters = mapOf("query-param" to "value"),
-        maxRedirectCount = 10
-    )
+    url = "https://www.vonage.com",
+    headers = mapOf("x-my-header" to "My Value"),
+    queryParameters = mapOf("query-param" to "value"),
+    maxRedirectCount = 10
+)
 
-    val response = VGNumberVerificationClient.getInstance().startNumberVerification(params, true)
+val response = VGNumberVerificationClient.getInstance().startNumberVerification(params, true)
 ```
 
 should be replaced with the `com.vonage:client-library` [example](#force-a-cellular-network-request) above.


### PR DESCRIPTION
## Summary

Brings the README up to date with changes shipped in 1.1.0.

- Add `getCellularStatus()` usage section (DEVX-11183)
- Document `operator_tracking` in debug response shape (DEVX-10955)
- Bump installation version from `1.0.1` to `1.1.0`
- Fix `VGCellularRequestClientParameters` → `VGCellularRequestParameters` (wrong class name)
- Fix error check from `optString("error") != ""` to `has("error")`
- Fix `startCellularRequest` → `startCellularGetRequest` (wrong method name)
- Fix migration guide typo `om.vonage` → `com.vonage`
- Switch response examples to JSON code blocks