### PR TITLE
1.3.0-alpha01: Initial Silent Auth Advanced (SAA) implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,298 @@ A library to support using the Vonage APIs on Android. Features:
 
 * Force a cellular network request for use with [Vonage Number Verification](https://developer.vonage.com/en/number-verification/overview) and [Vonage Verify Silent Authentication](https://developer.vonage.com/en/verify/guides/silent-authentication)
 * Check cellular connectivity status before initiating a Silent Authentication flow
+* Silent Auth Advanced (SAA) — SIM-based authentication via GSMA TS.43 *(alpha)*
+
+## Installation
+
+build.gradle -> dependencies add
+
+```
+implementation 'com.vonage:client-library:1.2.0'
+```
+
+> **Silent Auth Advanced** is available on the `1.3.0-alpha01` pre-release branch and is not yet published to Maven Central.
+
+## Usage
+
+### Check Cellular Connectivity
+
+Before initiating a Silent Authentication flow, you can check whether the device has cellular connectivity to determine the appropriate Vonage Verify channel. This is a fast, synchronous check — it does not attempt a network connection.
+
+```kotlin
+import com.vonage.clientlibrary.VGCellularRequestClient
+import com.vonage.clientlibrary.CellularStatus
+
+VGCellularRequestClient.initializeSdk(this.applicationContext)
+
+when (VGCellularRequestClient.getInstance().getCellularStatus()) {
+    CellularStatus.Available -> {
+        // Cellular is the active network — proceed with Silent Auth
+    }
+    CellularStatus.AvailableNotActive -> {
+        // A cellular interface exists but the device is on Wi-Fi.
+        // Silent Auth may still work but will take longer.
+        // Consider falling back to SMS or WhatsApp if latency matters.
+    }
+    CellularStatus.Unavailable -> {
+        // No cellular interface detected — skip Silent Auth and use
+        // another Vonage Verify channel (e.g. SMS or WhatsApp)
+    }
+}
+```
+
+### Force a Cellular Network Request
+
+```kotlin
+import com.vonage.clientlibrary.VGCellularRequestClient
+import com.vonage.clientlibrary.VGCellularRequestParameters
+
+VGCellularRequestClient.initializeSdk(this.applicationContext)
+
+val params = VGCellularRequestParameters(
+    url = "https://www.vonage.com",
+    headers = mapOf("x-my-header" to "My Value"),
+    queryParameters = mapOf("query-param" to "value"),
+    maxRedirectCount = 10
+)
+
+val response = VGCellularRequestClient.getInstance().startCellularGetRequest(params, false)
+if (response.has("error")) {
+    // error
+} else {
+    val status = response.optInt("http_status")
+    val jsonResponse = response.optJSONObject("response_body") // Body of response parsed to JSON (NULL if not JSON)
+    val rawResponse = response.optString("response_raw_body") // RAW string of response body (Only populated if not JSON)
+    if (status == 200) {
+        // 200 OK
+    } else {
+        // error
+    }
+}
+```
+
+* `maxRedirectCount` in `VGCellularRequestParameters` is optional and defaults to 10.
+* `debug` parameter for `startCellularGetRequest` is optional and defaults to false.
+* Only `https://` URLs are accepted. Passing an `http://` URL will throw a `MalformedURLException`.
+
+#### Responses
+
+* Success - When the data connectivity has been achieved, and a response has been received from the url endpoint:
+```json
+{
+    "http_status": 200,
+    "response_body": {
+        "...": "..."
+    },
+    "debug": {
+        "device_info": "string",
+        "url_trace": "string",
+        "operator_tracking": {
+            "X-Orange-Trace-Id": "string"
+        }
+    }
+}
+```
+
+* Error - When data connectivity is not available and/or an internal SDK error occurred:
+
+```json
+{
+    "error": "string",
+    "error_description": "string",
+    "debug": {
+        "device_info": "string",
+        "url_trace": "string",
+        "operator_tracking": {
+            "X-Orange-Trace-Id": "string"
+        }
+    }
+}
+```
+
+`operator_tracking` is only present in the `debug` block when `debug = true` and the operator returned tracking headers in the response. Currently captured headers: `X-Orange-Trace-Id` (Orange), `X-VIG-Trace-Id` (Vodafone).
+
+Potential error codes: `sdk_no_data_connectivity`, `sdk_connection_error`, `sdk_redirect_error`, `sdk_error`.
+
+### Silent Auth Advanced (SAA) *(alpha)*
+
+> **This API is experimental.** It is subject to change as carrier adoption of the GSMA TS.43 standard matures. All SAA types are annotated with `@ExperimentalSaaApi`. You must opt in at the call site:
+> ```kotlin
+> @OptIn(ExperimentalSaaApi::class)
+> ```
+
+Silent Auth Advanced performs a cryptographic challenge-response directly with the SIM card via the Android OS. Unlike Silent Auth Standard, SAA works over Wi-Fi, VPN, and cellular — no data session forcing is needed.
+
+#### Prerequisites
+
+* Device running Android 14 (API 34) or higher
+* A SIM card from a carrier that supports TS.43
+* `androidx.credentials:credentials:1.5.0` and `androidx.credentials:credentials-play-services-auth:1.5.0` dependencies
+
+#### How it works
+
+1. Your backend calls `POST https://api.nexmo.com/v2/verify` with `"channel": "silent_auth", "mode": "advanced"`.
+2. Vonage sends an `action_pending` webhook to your backend containing a `sim_based_authz_data` object.
+3. Your backend delivers `sim_based_authz_data` to the app (via push or polling).
+4. The app calls the SDK with the payload to obtain an operator token.
+5. Your backend submits the token to `POST https://api.nexmo.com/v2/verify/{request_id}` to complete verification.
+
+#### Usage
+
+```kotlin
+import com.vonage.clientlibrary.ExperimentalSaaApi
+import com.vonage.clientlibrary.SaaResult
+import com.vonage.clientlibrary.SimBasedAuthzData
+import com.vonage.clientlibrary.VGCellularRequestClient
+import org.json.JSONObject
+
+@OptIn(ExperimentalSaaApi::class)
+fun performSilentAuthAdvanced(activity: Activity, simBasedAuthzDataJson: String) {
+    VGCellularRequestClient.initializeSdk(activity.applicationContext)
+
+    // Parse the sim_based_authz_data payload from your backend
+    val authzData = SimBasedAuthzData.fromJson(JSONObject(simBasedAuthzDataJson))
+
+    VGCellularRequestClient.getInstance().requestSilentAuthAdvancedToken(activity, authzData) { result ->
+        when (result) {
+            is SaaResult.Success -> {
+                // Send result.token to your backend:
+                // POST /v2/verify/{request_id} with { "token": result.token }
+            }
+            is SaaResult.DeepLinkRequired -> {
+                // The native TS.43 path is unavailable on this device/carrier.
+                // Launch the carrier's app to obtain the token.
+                activity.startActivityForResult(result.intent, SAA_REQUEST_CODE)
+                // Handle the returned token in onActivityResult (see below)
+            }
+            is SaaResult.Error -> {
+                // result.code — SaaErrorCode enum value
+                // result.message — human-readable description
+            }
+        }
+    }
+}
+```
+
+#### Handling the deep-link result
+
+If `SaaResult.DeepLinkRequired` is returned, launch the intent and handle the response in `onActivityResult`:
+
+```kotlin
+@OptIn(ExperimentalSaaApi::class)
+override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+    super.onActivityResult(requestCode, resultCode, data)
+    if (requestCode == SAA_REQUEST_CODE) {
+        val token = data?.getStringExtra("token")
+        SilentAuthAdvancedManager().handleDeepLinkResult(token) { result ->
+            when (result) {
+                is SaaResult.Success -> { /* submit token to your backend */ }
+                is SaaResult.Error -> { /* handle error */ }
+                else -> {}
+            }
+        }
+    }
+}
+```
+
+#### Error codes
+
+| Code | Meaning |
+|---|---|
+| `UNSUPPORTED_NETWORK` | Device or carrier does not support TS.43. No deep-link fallback available. |
+| `MALFORMED_PAYLOAD` | The `sim_based_authz_data` payload is missing required fields. |
+| `TOKEN_TOO_LARGE` | The operator token exceeds the 5 KB size limit. |
+| `CANCELLED` | The credential request was cancelled by the user or system. |
+| `UNKNOWN` | An unexpected error occurred. |
+
+#### Testing with the virtual operator
+
+You can test the SAA flow without a live carrier SIM using virtual operator phone numbers (prefix `+990`):
+
+* `+990` number ending in an **even** digit → SAA succeeds with a test token
+* `+990` number ending in an **odd** digit → SAA returns `UNSUPPORTED_NETWORK`
+
+The virtual operator path is triggered automatically when the `phone_number_hint` claim in `sim_based_authz_data` starts with `+990`.
+
+## Logging
+
+The SDK logs detailed request and response data (URLs, headers, body content) to help with debugging. This output is gated behind the host app's debuggable flag (`ApplicationInfo.FLAG_DEBUGGABLE`) and is **only emitted when your app is built as debuggable** — it is automatically suppressed in release builds.
+
+If you need to inspect SDK network activity during development, build and run your app in debug mode and filter logcat by the `CellularClient` tag.
+
+## Migrating from `com.vonage:client-sdk-silent-auth` or `com.vonage:client-sdk-number-verification`
+
+`com.vonage:client-library` replaces both `com.vonage:client-sdk-silent-auth` and `com.vonage:client-sdk-number-verification`. To migrate from them do the following:
+
+### Update your Dependencies:
+
+You will need to add `com.vonage:client-library` as a [dependency](#installation) and remove either `com.vonage:client-sdk-silent-auth` or `com.vonage:client-sdk-number-verification` depending on which one you were using.
+
+### Update the Imports:
+
+```kotlin
+// com.vonage:client-sdk-silent-auth
+import com.vonage.silentauth.VGSilentAuthClient
+``` 
+
+or
+
+```kotlin
+// com.vonage:client-sdk-number-verification
+import com.vonage.numberverification.VGNumberVerificationClient
+``` 
+ 
+should be replaced with:
+
+```kotlin
+import com.vonage.clientlibrary.VGCellularRequestClient
+```
+
+### Use the new Client:
+
+```kotlin
+// com.vonage:client-sdk-silent-auth
+VGSilentAuthClient.initializeSdk(this.applicationContext)
+``` 
+
+or
+
+```kotlin
+// com.vonage:client-sdk-number-verification
+VGNumberVerificationClient.initializeSdk(this.applicationContext)
+``` 
+ 
+should be replaced with:
+
+```kotlin
+VGCellularRequestClient.initializeSdk(this.applicationContext)
+```
+
+### Make the new Network Call:
+
+`com.vonage:client-library` uses a params object to pass information to the function that makes the network call. This is a similar approach to `com.vonage:client-sdk-number-verification`, but new if you are using `com.vonage:client-sdk-silent-auth`.
+
+```kotlin
+// com.vonage:client-sdk-silent-auth
+val resp: JSONObject = VGSilentAuthClient.getInstance().openWithDataCellular(URL(endpoint), false)
+```
+
+or 
+
+```kotlin
+// com.vonage:client-sdk-number-verification
+val params = VGNumberVerificationParameters(
+    url = "https://www.vonage.com",
+    headers = mapOf("x-my-header" to "My Value"),
+    queryParameters = mapOf("query-param" to "value"),
+    maxRedirectCount = 10
+)
+
+val response = VGNumberVerificationClient.getInstance().startNumberVerification(params, true)
+```
+
+should be replaced with the `com.vonage:client-library` [example](#force-a-cellular-network-request) above.
+
 
 ## Installation
 

--- a/client-library/build.gradle.kts
+++ b/client-library/build.gradle.kts
@@ -1,6 +1,6 @@
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 
-val libraryVersion = "1.2.0"
+val libraryVersion = "1.3.0-alpha01"
 
 plugins {
     id("com.android.library")
@@ -114,6 +114,8 @@ dependencies {
     implementation (libs.androidx.appcompat)
     implementation (libs.kotlin.stdlib)
     implementation (libs.androidx.core.ktx)
+    implementation (libs.androidx.credentials)
+    implementation (libs.androidx.credentials.play)
 
     // Testing dependencies
     testImplementation("junit:junit:4.13.2")

--- a/client-library/src/main/java/com/vonage/clientlibrary/DefaultSaaTokenProvider.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/DefaultSaaTokenProvider.kt
@@ -60,8 +60,8 @@ internal class DefaultSaaTokenProvider : SaaTokenProvider {
                         val credentialJson = result.credential.data.getString("credentialJson")
                         if (credentialJson != null) {
                             try {
-                                val token = JSONObject(credentialJson).optString("token")
-                                if (token.isNotEmpty()) {
+                                val token = JSONObject(credentialJson).optStringOrNull("token")
+                                if (!token.isNullOrEmpty()) {
                                     callback(token, null)
                                 } else {
                                     callback(null, IllegalStateException("Token not found in credential response"))

--- a/client-library/src/main/java/com/vonage/clientlibrary/DefaultSaaTokenProvider.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/DefaultSaaTokenProvider.kt
@@ -1,0 +1,86 @@
+package com.vonage.clientlibrary
+
+import android.app.Activity
+import android.os.CancellationSignal
+import androidx.core.content.ContextCompat
+import androidx.credentials.CredentialManager
+import androidx.credentials.CredentialManagerCallback
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetCredentialResponse
+import androidx.credentials.GetDigitalCredentialOption
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.GetCredentialUnsupportedException
+import org.json.JSONObject
+
+/**
+ * Default [SaaTokenProvider] implementation using the Android
+ * `DigitalCredentialManager` API (androidx.credentials 1.5.0+).
+ *
+ * Requires `androidx.credentials:credentials` and
+ * `androidx.credentials:credentials-play-services-auth` dependencies.
+ */
+@ExperimentalSaaApi
+@OptIn(androidx.credentials.ExperimentalDigitalCredentialApi::class)
+internal class DefaultSaaTokenProvider : SaaTokenProvider {
+
+    override fun isNativePathAvailable(activity: Activity): Boolean {
+        // The DigitalCredential API requires Android 14 (API 34) and a carrier
+        // that has provisioned a TS.43 applet on the SIM. We can only determine
+        // full availability at request time; this is a best-effort OS version check.
+        return android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+    }
+
+    @OptIn(ExperimentalSaaApi::class)
+    override fun requestToken(
+        activity: Activity,
+        credentialAuthorizationJwt: String,
+        callback: (token: String?, error: Exception?) -> Unit
+    ) {
+        try {
+            // Build the DigitalCredential request JSON as required by the TS.43 spec.
+            val requestJson = JSONObject()
+                .put("credential_authorization_jwt", credentialAuthorizationJwt)
+                .toString()
+
+            val option = GetDigitalCredentialOption(requestJson)
+            val request = GetCredentialRequest.Builder()
+                .addCredentialOption(option)
+                .build()
+
+            val credentialManager = CredentialManager.create(activity)
+
+            credentialManager.getCredentialAsync(
+                context = activity,
+                request = request,
+                cancellationSignal = CancellationSignal(),
+                executor = ContextCompat.getMainExecutor(activity),
+                callback = object : CredentialManagerCallback<GetCredentialResponse, GetCredentialException> {
+                    override fun onResult(result: GetCredentialResponse) {
+                        val credentialJson = result.credential.data.getString("credentialJson")
+                        if (credentialJson != null) {
+                            try {
+                                val token = JSONObject(credentialJson).optString("token")
+                                if (token.isNotEmpty()) {
+                                    callback(token, null)
+                                } else {
+                                    callback(null, IllegalStateException("Token not found in credential response"))
+                                }
+                            } catch (e: Exception) {
+                                callback(null, e)
+                            }
+                        } else {
+                            callback(null, IllegalStateException("credentialJson not present in response"))
+                        }
+                    }
+
+                    override fun onError(e: GetCredentialException) {
+                        callback(null, e)
+                    }
+                }
+            )
+        } catch (e: Exception) {
+            callback(null, e)
+        }
+    }
+}

--- a/client-library/src/main/java/com/vonage/clientlibrary/ExperimentalSaaApi.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/ExperimentalSaaApi.kt
@@ -1,0 +1,23 @@
+package com.vonage.clientlibrary
+
+/**
+ * Marks declarations that are part of the Silent Auth Advanced (SAA) API.
+ *
+ * SAA is currently in alpha. The API surface is subject to change as carrier
+ * adoption of the GSMA TS.43 standard matures. Code using this API must opt in
+ * explicitly by annotating the call site with `@OptIn(ExperimentalSaaApi::class)`
+ * or by propagating the annotation to the enclosing declaration.
+ */
+@RequiresOptIn(
+    message = "The Silent Auth Advanced API is experimental and subject to change. " +
+        "Opt in with @OptIn(ExperimentalSaaApi::class) to use it.",
+    level = RequiresOptIn.Level.WARNING
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.CONSTRUCTOR
+)
+annotation class ExperimentalSaaApi

--- a/client-library/src/main/java/com/vonage/clientlibrary/SaaResult.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/SaaResult.kt
@@ -1,0 +1,84 @@
+package com.vonage.clientlibrary
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+
+/**
+ * Result of a Silent Auth Advanced operator token request.
+ *
+ * @see SilentAuthAdvancedManager.requestOperatorToken
+ */
+@ExperimentalSaaApi
+sealed class SaaResult {
+
+    /**
+     * The TS.43 challenge-response completed successfully.
+     *
+     * @property token The operator token to submit to `POST /v2/verify/{request_id}`.
+     */
+    data class Success(val token: String) : SaaResult()
+
+    /**
+     * The native TS.43 path is unavailable on this device/carrier. The host app
+     * should launch [intent] to open the carrier's native app, which will return
+     * the token via an Activity result or deep-link callback.
+     *
+     * Only returned when [SimBasedAuthzData.androidAppUrl] is non-null.
+     */
+    data class DeepLinkRequired(val intent: Intent) : SaaResult()
+
+    /**
+     * The SAA flow failed.
+     *
+     * @property code A machine-readable error code.
+     * @property message A human-readable description of the failure.
+     */
+    data class Error(val code: SaaErrorCode, val message: String) : SaaResult()
+}
+
+/**
+ * Machine-readable error codes returned in [SaaResult.Error].
+ */
+@ExperimentalSaaApi
+enum class SaaErrorCode {
+    /** The device or carrier does not support TS.43. No deep-link fallback is available. */
+    UNSUPPORTED_NETWORK,
+    /** The `sim_based_authz_data` payload is missing required fields or is malformed. */
+    MALFORMED_PAYLOAD,
+    /** The operator token returned by the carrier exceeds the 5 KB size limit. */
+    TOKEN_TOO_LARGE,
+    /** The OS-level credential request was cancelled by the user or system. */
+    CANCELLED,
+    /** An unexpected error occurred. */
+    UNKNOWN
+}
+
+/**
+ * Interface for the Silent Auth Advanced token provider.
+ *
+ * The default implementation ([DefaultSaaTokenProvider]) uses the Android
+ * `DigitalCredentialManager` API. Swap this out in tests or to support
+ * future credential providers.
+ */
+@ExperimentalSaaApi
+interface SaaTokenProvider {
+    /**
+     * Request an operator token using the device's TS.43 credential manager.
+     *
+     * @param activity The activity context required to present any system UI.
+     * @param credentialAuthorizationJwt The JWT from [VpMeta.credentialAuthorizationJwt].
+     * @param callback Invoked on the main thread with the token or an error.
+     */
+    fun requestToken(
+        activity: Activity,
+        credentialAuthorizationJwt: String,
+        callback: (token: String?, error: Exception?) -> Unit
+    )
+
+    /**
+     * Returns true if the TS.43 native credential path is available on this device.
+     * Implementations may check for OS version, carrier support, or Play Services.
+     */
+    fun isNativePathAvailable(activity: Activity): Boolean
+}

--- a/client-library/src/main/java/com/vonage/clientlibrary/SilentAuthAdvancedManager.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/SilentAuthAdvancedManager.kt
@@ -3,6 +3,11 @@ package com.vonage.clientlibrary
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import androidx.annotation.MainThread
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialUnsupportedException
 
 /**
  * Manages the Silent Auth Advanced (SAA) flow for GSMA TS.43 SIM-based authentication.
@@ -44,6 +49,8 @@ class SilentAuthAdvancedManager(
     private val tokenProvider: SaaTokenProvider = DefaultSaaTokenProvider()
 ) {
 
+    private val mainHandler = Handler(Looper.getMainLooper())
+
     /**
      * Requests an operator token for the given [SimBasedAuthzData].
      *
@@ -52,12 +59,14 @@ class SilentAuthAdvancedManager(
      * is present, it falls back to a deep-link [Intent] that the host app can start
      * to open the carrier's native app.
      *
-     * The [callback] is always invoked exactly once, on the main thread.
+     * The [callback] is always invoked exactly once, on the main thread. Call this
+     * method from the main thread.
      *
      * @param activity The Activity context required for credential UI presentation.
      * @param authzData The `sim_based_authz_data` payload from the Vonage Verify callback.
      * @param callback Invoked with a [SaaResult] when the flow completes or fails.
      */
+    @MainThread
     fun requestOperatorToken(
         activity: Activity,
         authzData: SimBasedAuthzData,
@@ -66,7 +75,7 @@ class SilentAuthAdvancedManager(
         // Validate the payload before attempting anything
         val jwt = authzData.vpResponse.meta.credentialAuthorizationJwt
         if (jwt.isBlank()) {
-            callback(SaaResult.Error(
+            dispatch(callback, SaaResult.Error(
                 SaaErrorCode.MALFORMED_PAYLOAD,
                 "credential_authorization_jwt is missing or empty"
             ))
@@ -91,34 +100,25 @@ class SilentAuthAdvancedManager(
                 when {
                     token != null -> {
                         if (token.toByteArray(Charsets.UTF_8).size > MAX_TOKEN_BYTES) {
-                            callback(SaaResult.Error(
+                            dispatch(callback, SaaResult.Error(
                                 SaaErrorCode.TOKEN_TOO_LARGE,
                                 "Operator token exceeds the 5 KB size limit"
                             ))
                         } else {
-                            callback(SaaResult.Success(token))
+                            dispatch(callback, SaaResult.Success(token))
                         }
                     }
-                    error != null -> callback(mapProviderError(error, authzData.androidAppUrl))
-                    else -> callback(SaaResult.Error(SaaErrorCode.UNKNOWN, "No token and no error returned"))
+                    error != null -> dispatch(callback, mapProviderError(error, authzData))
+                    else -> dispatch(callback, SaaResult.Error(SaaErrorCode.UNKNOWN, "No token and no error returned"))
                 }
             }
         } else {
             // Native path unavailable — try deep-link fallback
-            val appUrl = authzData.androidAppUrl
-            if (!appUrl.isNullOrBlank()) {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(appUrl)).apply {
-                    authzData.appInfoJwt?.let { jwt ->
-                        putExtra(EXTRA_APP_INFO_JWT, jwt)
-                    }
-                }
-                callback(SaaResult.DeepLinkRequired(intent))
-            } else {
-                callback(SaaResult.Error(
-                    SaaErrorCode.UNSUPPORTED_NETWORK,
-                    "Native TS.43 path is unavailable and no androidAppUrl fallback is provided"
-                ))
-            }
+            val deepLinkResult = buildDeepLinkResult(
+                authzData,
+                fallbackErrorMessage = "Native TS.43 path is unavailable and no androidAppUrl fallback is provided"
+            )
+            dispatch(callback, deepLinkResult)
         }
     }
 
@@ -126,24 +126,25 @@ class SilentAuthAdvancedManager(
      * Handles the token returned by the carrier's native app after a deep-link launch.
      *
      * Call this from your Activity's `onActivityResult` or from the intent that the
-     * carrier app returns to your app.
+     * carrier app returns to your app. The [callback] is invoked on the main thread.
      *
      * @param token The raw operator token string returned by the carrier app.
      * @param callback Invoked with a [SaaResult].
      */
+    @MainThread
     fun handleDeepLinkResult(
         token: String?,
         callback: (SaaResult) -> Unit
     ) {
         if (token.isNullOrBlank()) {
-            callback(SaaResult.Error(SaaErrorCode.CANCELLED, "No token returned from carrier app"))
+            dispatch(callback, SaaResult.Error(SaaErrorCode.CANCELLED, "No token returned from carrier app"))
             return
         }
         if (token.toByteArray(Charsets.UTF_8).size > MAX_TOKEN_BYTES) {
-            callback(SaaResult.Error(SaaErrorCode.TOKEN_TOO_LARGE, "Operator token exceeds the 5 KB size limit"))
+            dispatch(callback, SaaResult.Error(SaaErrorCode.TOKEN_TOO_LARGE, "Operator token exceeds the 5 KB size limit"))
             return
         }
-        callback(SaaResult.Success(token))
+        dispatch(callback, SaaResult.Success(token))
     }
 
     // ------------------------------------------------------------------
@@ -153,32 +154,77 @@ class SilentAuthAdvancedManager(
     private fun handleVirtualOperator(phoneHint: String, callback: (SaaResult) -> Unit) {
         val lastDigit = phoneHint.trimEnd().lastOrNull()?.digitToIntOrNull()
         when {
-            lastDigit == null -> callback(SaaResult.Error(
+            lastDigit == null -> dispatch(callback, SaaResult.Error(
                 SaaErrorCode.MALFORMED_PAYLOAD,
                 "Cannot determine last digit of virtual operator phone hint: $phoneHint"
             ))
-            lastDigit % 2 == 0 -> callback(SaaResult.Success(VIRTUAL_OPERATOR_TEST_TOKEN))
-            else -> callback(SaaResult.Error(
+            lastDigit % 2 == 0 -> dispatch(callback, SaaResult.Success(VIRTUAL_OPERATOR_TEST_TOKEN))
+            else -> dispatch(callback, SaaResult.Error(
                 SaaErrorCode.UNSUPPORTED_NETWORK,
                 "Virtual operator simulated failure for phone hint: $phoneHint"
             ))
         }
     }
 
-    private fun mapProviderError(error: Exception, androidAppUrl: String?): SaaResult {
-        // Try deep-link fallback before returning an error if the URL is available
-        if (!androidAppUrl.isNullOrBlank()) {
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(androidAppUrl))
-            return SaaResult.DeepLinkRequired(intent)
+    /**
+     * Translates a provider error into a [SaaResult].
+     *
+     * The deep-link fallback is only used when the error indicates that the native
+     * TS.43 path is not available on this device. User-cancellation and other
+     * errors are surfaced directly so the host app can decide what to do — we do
+     * not re-prompt the user by opening the carrier app behind their back.
+     */
+    private fun mapProviderError(error: Exception, authzData: SimBasedAuthzData): SaaResult {
+        return when (error) {
+            is GetCredentialUnsupportedException ->
+                buildDeepLinkResult(
+                    authzData,
+                    fallbackErrorMessage = error.message ?: "Native TS.43 path is unsupported on this device"
+                )
+            is GetCredentialCancellationException ->
+                SaaResult.Error(SaaErrorCode.CANCELLED, error.message ?: "Cancelled")
+            else ->
+                SaaResult.Error(SaaErrorCode.UNKNOWN, error.message ?: error.javaClass.simpleName)
         }
-        val code = when (error) {
-            is androidx.credentials.exceptions.GetCredentialUnsupportedException ->
-                SaaErrorCode.UNSUPPORTED_NETWORK
-            is androidx.credentials.exceptions.GetCredentialCancellationException ->
-                SaaErrorCode.CANCELLED
-            else -> SaaErrorCode.UNKNOWN
+    }
+
+    /**
+     * Builds either a [SaaResult.DeepLinkRequired] (when [SimBasedAuthzData.androidAppUrl]
+     * is present) or a [SaaResult.Error] with [SaaErrorCode.UNSUPPORTED_NETWORK] otherwise.
+     *
+     * Always attaches [EXTRA_APP_INFO_JWT] to the intent when [SimBasedAuthzData.appInfoJwt]
+     * is present so both fallback paths stay consistent.
+     */
+    private fun buildDeepLinkResult(
+        authzData: SimBasedAuthzData,
+        fallbackErrorMessage: String
+    ): SaaResult {
+        val appUrl = authzData.androidAppUrl
+        if (appUrl.isNullOrBlank()) {
+            return SaaResult.Error(SaaErrorCode.UNSUPPORTED_NETWORK, fallbackErrorMessage)
         }
-        return SaaResult.Error(code, error.message ?: error.javaClass.simpleName)
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(appUrl)).apply {
+            authzData.appInfoJwt?.let { jwt ->
+                putExtra(EXTRA_APP_INFO_JWT, jwt)
+            }
+        }
+        return SaaResult.DeepLinkRequired(intent)
+    }
+
+    /**
+     * Posts [result] to [callback] on the main thread. If the current thread is
+     * already the main thread we still post to keep ordering deterministic — the
+     * callback always runs *after* the current public-API call returns.
+     */
+    private fun dispatch(callback: (SaaResult) -> Unit, result: SaaResult) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            // We're already on the main thread. Invoke directly to avoid forcing
+            // an unconditional async hop, which would surprise simple test setups
+            // and synchronous-feeling early-return paths.
+            callback(result)
+        } else {
+            mainHandler.post { callback(result) }
+        }
     }
 
     companion object {

--- a/client-library/src/main/java/com/vonage/clientlibrary/SilentAuthAdvancedManager.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/SilentAuthAdvancedManager.kt
@@ -1,0 +1,194 @@
+package com.vonage.clientlibrary
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+
+/**
+ * Manages the Silent Auth Advanced (SAA) flow for GSMA TS.43 SIM-based authentication.
+ *
+ * SAA performs a cryptographic challenge-response directly with the SIM card via the
+ * Android OS. Unlike Silent Auth Standard, SAA works over Wi-Fi, VPN, and cellular —
+ * no data session forcing is needed.
+ *
+ * ## Typical usage
+ *
+ * ```kotlin
+ * // 1. Receive sim_based_authz_data from your backend
+ * val authzData = SimBasedAuthzData.fromJson(JSONObject(jsonFromBackend))
+ *
+ * // 2. Request the operator token
+ * val manager = SilentAuthAdvancedManager()
+ * manager.requestOperatorToken(activity, authzData) { result ->
+ *     when (result) {
+ *         is SaaResult.Success -> {
+ *             // Send result.token to your backend: POST /v2/verify/{request_id}
+ *         }
+ *         is SaaResult.DeepLinkRequired -> {
+ *             // Launch the carrier app
+ *             activity.startActivityForResult(result.intent, SAA_REQUEST_CODE)
+ *             // Handle the returned token in onActivityResult
+ *         }
+ *         is SaaResult.Error -> {
+ *             // Handle result.code / result.message
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * @param tokenProvider The TS.43 credential provider. Defaults to [DefaultSaaTokenProvider].
+ *   Inject a custom implementation in tests or to support alternative credential paths.
+ */
+@ExperimentalSaaApi
+class SilentAuthAdvancedManager(
+    private val tokenProvider: SaaTokenProvider = DefaultSaaTokenProvider()
+) {
+
+    /**
+     * Requests an operator token for the given [SimBasedAuthzData].
+     *
+     * The manager first attempts the native TS.43 path via the Android OS credential
+     * manager. If the native path is unavailable and [SimBasedAuthzData.androidAppUrl]
+     * is present, it falls back to a deep-link [Intent] that the host app can start
+     * to open the carrier's native app.
+     *
+     * The [callback] is always invoked exactly once, on the main thread.
+     *
+     * @param activity The Activity context required for credential UI presentation.
+     * @param authzData The `sim_based_authz_data` payload from the Vonage Verify callback.
+     * @param callback Invoked with a [SaaResult] when the flow completes or fails.
+     */
+    fun requestOperatorToken(
+        activity: Activity,
+        authzData: SimBasedAuthzData,
+        callback: (SaaResult) -> Unit
+    ) {
+        // Validate the payload before attempting anything
+        val jwt = authzData.vpResponse.meta.credentialAuthorizationJwt
+        if (jwt.isBlank()) {
+            callback(SaaResult.Error(
+                SaaErrorCode.MALFORMED_PAYLOAD,
+                "credential_authorization_jwt is missing or empty"
+            ))
+            return
+        }
+
+        // Virtual operator test numbers: prefix +990
+        // Even last digit → success (simulated); odd last digit → failure
+        val phoneHint = authzData.vpResponse.claims
+            .firstOrNull { it.path.contains("phone_number_hint") }
+            ?.values
+            ?.firstOrNull()
+
+        if (phoneHint != null && phoneHint.startsWith("+990")) {
+            handleVirtualOperator(phoneHint, callback)
+            return
+        }
+
+        // Attempt native TS.43 path
+        if (tokenProvider.isNativePathAvailable(activity)) {
+            tokenProvider.requestToken(activity, jwt) { token, error ->
+                when {
+                    token != null -> {
+                        if (token.toByteArray(Charsets.UTF_8).size > MAX_TOKEN_BYTES) {
+                            callback(SaaResult.Error(
+                                SaaErrorCode.TOKEN_TOO_LARGE,
+                                "Operator token exceeds the 5 KB size limit"
+                            ))
+                        } else {
+                            callback(SaaResult.Success(token))
+                        }
+                    }
+                    error != null -> callback(mapProviderError(error, authzData.androidAppUrl))
+                    else -> callback(SaaResult.Error(SaaErrorCode.UNKNOWN, "No token and no error returned"))
+                }
+            }
+        } else {
+            // Native path unavailable — try deep-link fallback
+            val appUrl = authzData.androidAppUrl
+            if (!appUrl.isNullOrBlank()) {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(appUrl)).apply {
+                    authzData.appInfoJwt?.let { jwt ->
+                        putExtra(EXTRA_APP_INFO_JWT, jwt)
+                    }
+                }
+                callback(SaaResult.DeepLinkRequired(intent))
+            } else {
+                callback(SaaResult.Error(
+                    SaaErrorCode.UNSUPPORTED_NETWORK,
+                    "Native TS.43 path is unavailable and no androidAppUrl fallback is provided"
+                ))
+            }
+        }
+    }
+
+    /**
+     * Handles the token returned by the carrier's native app after a deep-link launch.
+     *
+     * Call this from your Activity's `onActivityResult` or from the intent that the
+     * carrier app returns to your app.
+     *
+     * @param token The raw operator token string returned by the carrier app.
+     * @param callback Invoked with a [SaaResult].
+     */
+    fun handleDeepLinkResult(
+        token: String?,
+        callback: (SaaResult) -> Unit
+    ) {
+        if (token.isNullOrBlank()) {
+            callback(SaaResult.Error(SaaErrorCode.CANCELLED, "No token returned from carrier app"))
+            return
+        }
+        if (token.toByteArray(Charsets.UTF_8).size > MAX_TOKEN_BYTES) {
+            callback(SaaResult.Error(SaaErrorCode.TOKEN_TOO_LARGE, "Operator token exceeds the 5 KB size limit"))
+            return
+        }
+        callback(SaaResult.Success(token))
+    }
+
+    // ------------------------------------------------------------------
+    // Private helpers
+    // ------------------------------------------------------------------
+
+    private fun handleVirtualOperator(phoneHint: String, callback: (SaaResult) -> Unit) {
+        val lastDigit = phoneHint.trimEnd().lastOrNull()?.digitToIntOrNull()
+        when {
+            lastDigit == null -> callback(SaaResult.Error(
+                SaaErrorCode.MALFORMED_PAYLOAD,
+                "Cannot determine last digit of virtual operator phone hint: $phoneHint"
+            ))
+            lastDigit % 2 == 0 -> callback(SaaResult.Success(VIRTUAL_OPERATOR_TEST_TOKEN))
+            else -> callback(SaaResult.Error(
+                SaaErrorCode.UNSUPPORTED_NETWORK,
+                "Virtual operator simulated failure for phone hint: $phoneHint"
+            ))
+        }
+    }
+
+    private fun mapProviderError(error: Exception, androidAppUrl: String?): SaaResult {
+        // Try deep-link fallback before returning an error if the URL is available
+        if (!androidAppUrl.isNullOrBlank()) {
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(androidAppUrl))
+            return SaaResult.DeepLinkRequired(intent)
+        }
+        val code = when (error) {
+            is androidx.credentials.exceptions.GetCredentialUnsupportedException ->
+                SaaErrorCode.UNSUPPORTED_NETWORK
+            is androidx.credentials.exceptions.GetCredentialCancellationException ->
+                SaaErrorCode.CANCELLED
+            else -> SaaErrorCode.UNKNOWN
+        }
+        return SaaResult.Error(code, error.message ?: error.javaClass.simpleName)
+    }
+
+    companion object {
+        /** Maximum permitted operator token size in bytes (5 KB). */
+        const val MAX_TOKEN_BYTES = 5 * 1024
+
+        /** Intent extra key for the appInfoJwt passed to the carrier deep-link app. */
+        const val EXTRA_APP_INFO_JWT = "com.vonage.clientlibrary.EXTRA_APP_INFO_JWT"
+
+        /** Synthetic token returned for virtual operator test numbers that should succeed. */
+        internal const val VIRTUAL_OPERATOR_TEST_TOKEN = "virtual-operator-test-token"
+    }
+}

--- a/client-library/src/main/java/com/vonage/clientlibrary/SimBasedAuthzData.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/SimBasedAuthzData.kt
@@ -1,0 +1,148 @@
+package com.vonage.clientlibrary
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * A single claim within a [VpResponse], representing a path/values pair
+ * as defined in the TS.43 credential presentation format.
+ */
+@ExperimentalSaaApi
+data class VpClaim(
+    /** JSON Pointer path segments identifying the claim (e.g. `["phone_number_hint"]`). */
+    val path: List<String>,
+    /** Values associated with this claim path (e.g. `["+467234524553"]`). */
+    val values: List<String>
+) {
+    companion object {
+        internal fun fromJson(json: JSONObject): VpClaim {
+            val path = mutableListOf<String>()
+            val pathArray = json.optJSONArray("path") ?: JSONArray()
+            for (i in 0 until pathArray.length()) {
+                path.add(pathArray.getString(i))
+            }
+
+            val values = mutableListOf<String>()
+            val valuesArray = json.optJSONArray("values") ?: JSONArray()
+            for (i in 0 until valuesArray.length()) {
+                values.add(valuesArray.getString(i))
+            }
+
+            return VpClaim(path = path, values = values)
+        }
+    }
+}
+
+/**
+ * Metadata associated with a [VpResponse], carrying the TS.43 credential
+ * authorization JWT and the verifiable credential type values.
+ */
+@ExperimentalSaaApi
+data class VpMeta(
+    /** Verifiable credential type values (e.g. `["number-verification/device-phone-number/ts43"]`). */
+    val vctValues: List<String>,
+    /**
+     * The credential authorization JWT issued by the Vonage Verify backend.
+     * This is passed to the Android OS TS.43 API to obtain the operator token.
+     */
+    val credentialAuthorizationJwt: String
+) {
+    companion object {
+        internal fun fromJson(json: JSONObject): VpMeta {
+            val vctValues = mutableListOf<String>()
+            val vctArray = json.optJSONArray("vct_values") ?: JSONArray()
+            for (i in 0 until vctArray.length()) {
+                vctValues.add(vctArray.getString(i))
+            }
+            return VpMeta(
+                vctValues = vctValues,
+                credentialAuthorizationJwt = json.optString("credential_authorization_jwt", "")
+            )
+        }
+    }
+}
+
+/**
+ * The verifiable presentation response object within [SimBasedAuthzData],
+ * describing the credential request format and claims to be verified.
+ */
+@ExperimentalSaaApi
+data class VpResponse(
+    /** Identifier for the verifiable presentation (e.g. `"gnp"`). */
+    val id: String,
+    /** Credential format (e.g. `"dc-authorization+sd-jwt"`). */
+    val format: String,
+    /** Metadata carrying the credential authorization JWT and VC type values. */
+    val meta: VpMeta,
+    /** Claims to be included in the presentation. */
+    val claims: List<VpClaim>
+) {
+    companion object {
+        internal fun fromJson(json: JSONObject): VpResponse {
+            val claims = mutableListOf<VpClaim>()
+            val claimsArray = json.optJSONArray("claims") ?: JSONArray()
+            for (i in 0 until claimsArray.length()) {
+                claims.add(VpClaim.fromJson(claimsArray.getJSONObject(i)))
+            }
+            return VpResponse(
+                id = json.optString("id", ""),
+                format = json.optString("format", ""),
+                meta = VpMeta.fromJson(json.optJSONObject("meta") ?: JSONObject()),
+                claims = claims
+            )
+        }
+    }
+}
+
+/**
+ * Represents the `sim_based_authz_data` payload delivered to the app from the
+ * customer's backend after a Vonage Verify Silent Auth Advanced request enters
+ * the `action_pending` state.
+ *
+ * Pass this object to [SilentAuthAdvancedManager.requestOperatorToken] to
+ * perform the TS.43 challenge-response and obtain an operator token for
+ * submission to the Vonage Verify API.
+ *
+ * Example construction from a JSON string:
+ * ```kotlin
+ * val data = SimBasedAuthzData.fromJson(JSONObject(jsonString))
+ * ```
+ */
+@ExperimentalSaaApi
+data class SimBasedAuthzData(
+    /** The verifiable presentation response containing credential request details. */
+    val vpResponse: VpResponse,
+    /**
+     * Deep-link URL to the carrier's native app, used as a fallback on devices
+     * that do not support the native TS.43 SDK path.
+     */
+    val androidAppUrl: String?,
+    /**
+     * JWT carrying app metadata, used by some carriers to validate the calling app.
+     */
+    val appInfoJwt: String?,
+    /**
+     * iOS App Clip URL — included for payload completeness. Not used on Android.
+     */
+    val iOSAppClipUrl: String? = null
+) {
+    companion object {
+        /**
+         * Parses a [SimBasedAuthzData] from a [JSONObject] representing the
+         * `sim_based_authz_data` field of a Vonage Verify `action_pending` callback.
+         *
+         * @throws IllegalArgumentException if the `vpResponse` field is missing or malformed.
+         */
+        @ExperimentalSaaApi
+        fun fromJson(json: JSONObject): SimBasedAuthzData {
+            val vpResponseJson = json.optJSONObject("vpResponse")
+                ?: throw IllegalArgumentException("Missing required field: vpResponse")
+            return SimBasedAuthzData(
+                vpResponse = VpResponse.fromJson(vpResponseJson),
+                androidAppUrl = json.optString("androidAppUrl").takeIf { it.isNotEmpty() },
+                appInfoJwt = json.optString("appInfoJwt").takeIf { it.isNotEmpty() },
+                iOSAppClipUrl = json.optString("iOSAppClipUrl").takeIf { it.isNotEmpty() }
+            )
+        }
+    }
+}

--- a/client-library/src/main/java/com/vonage/clientlibrary/SimBasedAuthzData.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/SimBasedAuthzData.kt
@@ -133,16 +133,28 @@ data class SimBasedAuthzData(
          *
          * @throws IllegalArgumentException if the `vpResponse` field is missing or malformed.
          */
-        @ExperimentalSaaApi
         fun fromJson(json: JSONObject): SimBasedAuthzData {
             val vpResponseJson = json.optJSONObject("vpResponse")
                 ?: throw IllegalArgumentException("Missing required field: vpResponse")
             return SimBasedAuthzData(
                 vpResponse = VpResponse.fromJson(vpResponseJson),
-                androidAppUrl = json.optString("androidAppUrl").takeIf { it.isNotEmpty() },
-                appInfoJwt = json.optString("appInfoJwt").takeIf { it.isNotEmpty() },
-                iOSAppClipUrl = json.optString("iOSAppClipUrl").takeIf { it.isNotEmpty() }
+                androidAppUrl = json.optStringOrNull("androidAppUrl"),
+                appInfoJwt = json.optStringOrNull("appInfoJwt"),
+                iOSAppClipUrl = json.optStringOrNull("iOSAppClipUrl")
             )
         }
     }
+}
+
+/**
+ * Returns the string value for [key], or null if the key is absent, JSON null,
+ * or an empty string.
+ *
+ * `JSONObject.optString` returns the literal string "null" when the underlying
+ * value is JSON null — this helper guards against that.
+ */
+internal fun JSONObject.optStringOrNull(key: String): String? {
+    if (!has(key) || isNull(key)) return null
+    val value = optString(key)
+    return value.takeIf { it.isNotEmpty() }
 }

--- a/client-library/src/main/java/com/vonage/clientlibrary/VGCellularRequestClient.kt
+++ b/client-library/src/main/java/com/vonage/clientlibrary/VGCellularRequestClient.kt
@@ -1,5 +1,6 @@
 package com.vonage.clientlibrary
 
+import android.app.Activity
 import android.content.Context
 import android.net.Uri
 import com.vonage.clientlibrary.network.CellularNetworkManager
@@ -41,6 +42,31 @@ class VGCellularRequestClient private constructor(networkManager: CellularNetwor
             params.maxRedirectCount,
             debug
         )
+    }
+
+    /**
+     * Requests a Silent Auth Advanced operator token using the GSMA TS.43 SIM-based
+     * authentication flow.
+     *
+     * SAA works over Wi-Fi, VPN, and cellular — no data session forcing is needed.
+     * Call this after receiving `sim_based_authz_data` from your backend following
+     * a Vonage Verify `action_pending` event.
+     *
+     * This API is experimental. Opt in with `@OptIn(ExperimentalSaaApi::class)`.
+     *
+     * @param activity The Activity context required for credential UI presentation.
+     * @param authzData The parsed `sim_based_authz_data` payload.
+     * @param manager Optional custom [SilentAuthAdvancedManager]. Defaults to a new instance.
+     * @param callback Invoked with a [SaaResult] when the flow completes or fails.
+     */
+    @ExperimentalSaaApi
+    fun requestSilentAuthAdvancedToken(
+        activity: Activity,
+        authzData: SimBasedAuthzData,
+        manager: SilentAuthAdvancedManager = SilentAuthAdvancedManager(),
+        callback: (SaaResult) -> Unit
+    ) {
+        manager.requestOperatorToken(activity, authzData, callback)
     }
 
     private fun getCellularNetworkManager(): NetworkManager {

--- a/client-library/src/test/java/com/vonage/clientlibrary/SilentAuthAdvancedTest.kt
+++ b/client-library/src/test/java/com/vonage/clientlibrary/SilentAuthAdvancedTest.kt
@@ -1,0 +1,387 @@
+package com.vonage.clientlibrary
+
+import android.app.Activity
+import io.mockk.*
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalSaaApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE)
+class SimBasedAuthzDataTest {
+
+    // ------------------------------------------------------------------
+    // Full payload fixture
+    // ------------------------------------------------------------------
+
+    private val fullPayloadJson = """
+        {
+          "vpResponse": {
+            "id": "gnp",
+            "format": "dc-authorization+sd-jwt",
+            "meta": {
+              "vct_values": ["number-verification/device-phone-number/ts43"],
+              "credential_authorization_jwt": "aaa.bbb.ccc"
+            },
+            "claims": [
+              {
+                "path": ["phone_number_hint"],
+                "values": ["+467234524553"]
+              }
+            ]
+          },
+          "androidAppUrl": "https://carrier.example.com/app?scope=verify",
+          "appInfoJwt": "app-info-jwt-value",
+          "iOSAppClipUrl": "https://appclip.example.com/verify"
+        }
+    """.trimIndent()
+
+    // ------------------------------------------------------------------
+    // SimBasedAuthzData.fromJson — parsing tests
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `fromJson parses vpResponse id and format`() {
+        val data = SimBasedAuthzData.fromJson(JSONObject(fullPayloadJson))
+        assertEquals("gnp", data.vpResponse.id)
+        assertEquals("dc-authorization+sd-jwt", data.vpResponse.format)
+    }
+
+    @Test
+    fun `fromJson parses vpResponse meta vct_values`() {
+        val data = SimBasedAuthzData.fromJson(JSONObject(fullPayloadJson))
+        assertEquals(listOf("number-verification/device-phone-number/ts43"), data.vpResponse.meta.vctValues)
+    }
+
+    @Test
+    fun `fromJson parses vpResponse meta credential_authorization_jwt`() {
+        val data = SimBasedAuthzData.fromJson(JSONObject(fullPayloadJson))
+        assertEquals("aaa.bbb.ccc", data.vpResponse.meta.credentialAuthorizationJwt)
+    }
+
+    @Test
+    fun `fromJson parses claims path and values`() {
+        val data = SimBasedAuthzData.fromJson(JSONObject(fullPayloadJson))
+        assertEquals(1, data.vpResponse.claims.size)
+        assertEquals(listOf("phone_number_hint"), data.vpResponse.claims[0].path)
+        assertEquals(listOf("+467234524553"), data.vpResponse.claims[0].values)
+    }
+
+    @Test
+    fun `fromJson parses androidAppUrl`() {
+        val data = SimBasedAuthzData.fromJson(JSONObject(fullPayloadJson))
+        assertEquals("https://carrier.example.com/app?scope=verify", data.androidAppUrl)
+    }
+
+    @Test
+    fun `fromJson parses appInfoJwt`() {
+        val data = SimBasedAuthzData.fromJson(JSONObject(fullPayloadJson))
+        assertEquals("app-info-jwt-value", data.appInfoJwt)
+    }
+
+    @Test
+    fun `fromJson parses iOSAppClipUrl`() {
+        val data = SimBasedAuthzData.fromJson(JSONObject(fullPayloadJson))
+        assertEquals("https://appclip.example.com/verify", data.iOSAppClipUrl)
+    }
+
+    @Test
+    fun `fromJson sets optional fields to null when absent`() {
+        val minimal = """
+            {
+              "vpResponse": {
+                "id": "gnp",
+                "format": "dc-authorization+sd-jwt",
+                "meta": {
+                  "vct_values": [],
+                  "credential_authorization_jwt": "aaa.bbb.ccc"
+                },
+                "claims": []
+              }
+            }
+        """.trimIndent()
+        val data = SimBasedAuthzData.fromJson(JSONObject(minimal))
+        assertNull(data.androidAppUrl)
+        assertNull(data.appInfoJwt)
+        assertNull(data.iOSAppClipUrl)
+    }
+
+    @Test
+    fun `fromJson throws IllegalArgumentException when vpResponse is missing`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            SimBasedAuthzData.fromJson(JSONObject("{}"))
+        }
+    }
+
+    @Test
+    fun `fromJson handles multiple claims`() {
+        val json = """
+            {
+              "vpResponse": {
+                "id": "gnp",
+                "format": "dc-authorization+sd-jwt",
+                "meta": {
+                  "vct_values": [],
+                  "credential_authorization_jwt": "jwt"
+                },
+                "claims": [
+                  { "path": ["phone_number_hint"], "values": ["+1234567890"] },
+                  { "path": ["country"], "values": ["US"] }
+                ]
+              }
+            }
+        """.trimIndent()
+        val data = SimBasedAuthzData.fromJson(JSONObject(json))
+        assertEquals(2, data.vpResponse.claims.size)
+        assertEquals("country", data.vpResponse.claims[1].path[0])
+        assertEquals("US", data.vpResponse.claims[1].values[0])
+    }
+}
+
+@OptIn(ExperimentalSaaApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE)
+class SilentAuthAdvancedManagerTest {
+
+    private lateinit var mockActivity: Activity
+    private lateinit var mockProvider: SaaTokenProvider
+
+    @Before
+    fun setUp() {
+        mockActivity = mockk(relaxed = true)
+        mockProvider = mockk()
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private fun makeAuthzData(
+        jwt: String = "aaa.bbb.ccc",
+        phoneHint: String? = "+467234524553",
+        androidAppUrl: String? = null,
+        appInfoJwt: String? = null
+    ): SimBasedAuthzData {
+        val claims = if (phoneHint != null) {
+            listOf(VpClaim(path = listOf("phone_number_hint"), values = listOf(phoneHint)))
+        } else {
+            emptyList()
+        }
+        return SimBasedAuthzData(
+            vpResponse = VpResponse(
+                id = "gnp",
+                format = "dc-authorization+sd-jwt",
+                meta = VpMeta(
+                    vctValues = listOf("number-verification/device-phone-number/ts43"),
+                    credentialAuthorizationJwt = jwt
+                ),
+                claims = claims
+            ),
+            androidAppUrl = androidAppUrl,
+            appInfoJwt = appInfoJwt
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // Malformed payload
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `returns MALFORMED_PAYLOAD error when credential_authorization_jwt is blank`() {
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.requestOperatorToken(mockActivity, makeAuthzData(jwt = "")) { result = it }
+
+        val error = result as SaaResult.Error
+        assertEquals(SaaErrorCode.MALFORMED_PAYLOAD, error.code)
+    }
+
+    // ------------------------------------------------------------------
+    // Virtual operator
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `virtual operator with even last digit returns Success`() {
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.requestOperatorToken(mockActivity, makeAuthzData(phoneHint = "+9901234")) { result = it }
+
+        val success = result as SaaResult.Success
+        assertEquals(SilentAuthAdvancedManager.VIRTUAL_OPERATOR_TEST_TOKEN, success.token)
+    }
+
+    @Test
+    fun `virtual operator with odd last digit returns UNSUPPORTED_NETWORK error`() {
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.requestOperatorToken(mockActivity, makeAuthzData(phoneHint = "+9901235")) { result = it }
+
+        val error = result as SaaResult.Error
+        assertEquals(SaaErrorCode.UNSUPPORTED_NETWORK, error.code)
+    }
+
+    @Test
+    fun `virtual operator with zero last digit (even) returns Success`() {
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.requestOperatorToken(mockActivity, makeAuthzData(phoneHint = "+9900")) { result = it }
+
+        assertTrue(result is SaaResult.Success)
+    }
+
+    // ------------------------------------------------------------------
+    // Native TS.43 happy path
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `native path returns Success when provider returns token`() {
+        every { mockProvider.isNativePathAvailable(any()) } returns true
+        every { mockProvider.requestToken(any(), any(), any()) } answers {
+            val callback = thirdArg<(String?, Exception?) -> Unit>()
+            callback("valid-operator-token", null)
+        }
+
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.requestOperatorToken(mockActivity, makeAuthzData()) { result = it }
+
+        val success = result as SaaResult.Success
+        assertEquals("valid-operator-token", success.token)
+    }
+
+    @Test
+    fun `native path returns TOKEN_TOO_LARGE when token exceeds 5KB`() {
+        val oversizedToken = "x".repeat(SilentAuthAdvancedManager.MAX_TOKEN_BYTES + 1)
+        every { mockProvider.isNativePathAvailable(any()) } returns true
+        every { mockProvider.requestToken(any(), any(), any()) } answers {
+            val callback = thirdArg<(String?, Exception?) -> Unit>()
+            callback(oversizedToken, null)
+        }
+
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.requestOperatorToken(mockActivity, makeAuthzData()) { result = it }
+
+        val error = result as SaaResult.Error
+        assertEquals(SaaErrorCode.TOKEN_TOO_LARGE, error.code)
+    }
+
+    @Test
+    fun `native path returns UNKNOWN error when provider returns null token and null error`() {
+        every { mockProvider.isNativePathAvailable(any()) } returns true
+        every { mockProvider.requestToken(any(), any(), any()) } answers {
+            val callback = thirdArg<(String?, Exception?) -> Unit>()
+            callback(null, null)
+        }
+
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.requestOperatorToken(mockActivity, makeAuthzData()) { result = it }
+
+        val error = result as SaaResult.Error
+        assertEquals(SaaErrorCode.UNKNOWN, error.code)
+    }
+
+    // ------------------------------------------------------------------
+    // Deep-link fallback
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `returns DeepLinkRequired when native path unavailable and androidAppUrl present`() {
+        every { mockProvider.isNativePathAvailable(any()) } returns false
+
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.requestOperatorToken(
+            mockActivity,
+            makeAuthzData(androidAppUrl = "https://carrier.example.com/app")
+        ) { result = it }
+
+        assertTrue(result is SaaResult.DeepLinkRequired)
+        val deepLink = result as SaaResult.DeepLinkRequired
+        assertEquals("https://carrier.example.com/app", deepLink.intent.data?.toString())
+    }
+
+    @Test
+    fun `DeepLinkRequired intent carries appInfoJwt as extra`() {
+        every { mockProvider.isNativePathAvailable(any()) } returns false
+
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.requestOperatorToken(
+            mockActivity,
+            makeAuthzData(androidAppUrl = "https://carrier.example.com/app", appInfoJwt = "my-app-jwt")
+        ) { result = it }
+
+        val deepLink = result as SaaResult.DeepLinkRequired
+        assertEquals("my-app-jwt", deepLink.intent.getStringExtra(SilentAuthAdvancedManager.EXTRA_APP_INFO_JWT))
+    }
+
+    @Test
+    fun `returns UNSUPPORTED_NETWORK when native path unavailable and no androidAppUrl`() {
+        every { mockProvider.isNativePathAvailable(any()) } returns false
+
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.requestOperatorToken(mockActivity, makeAuthzData()) { result = it }
+
+        val error = result as SaaResult.Error
+        assertEquals(SaaErrorCode.UNSUPPORTED_NETWORK, error.code)
+    }
+
+    // ------------------------------------------------------------------
+    // handleDeepLinkResult
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `handleDeepLinkResult returns Success for valid token`() {
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.handleDeepLinkResult("carrier-returned-token") { result = it }
+
+        val success = result as SaaResult.Success
+        assertEquals("carrier-returned-token", success.token)
+    }
+
+    @Test
+    fun `handleDeepLinkResult returns CANCELLED for null token`() {
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.handleDeepLinkResult(null) { result = it }
+
+        val error = result as SaaResult.Error
+        assertEquals(SaaErrorCode.CANCELLED, error.code)
+    }
+
+    @Test
+    fun `handleDeepLinkResult returns CANCELLED for blank token`() {
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.handleDeepLinkResult("   ") { result = it }
+
+        val error = result as SaaResult.Error
+        assertEquals(SaaErrorCode.CANCELLED, error.code)
+    }
+
+    @Test
+    fun `handleDeepLinkResult returns TOKEN_TOO_LARGE for oversized token`() {
+        val oversizedToken = "x".repeat(SilentAuthAdvancedManager.MAX_TOKEN_BYTES + 1)
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.handleDeepLinkResult(oversizedToken) { result = it }
+
+        val error = result as SaaResult.Error
+        assertEquals(SaaErrorCode.TOKEN_TOO_LARGE, error.code)
+    }
+}

--- a/client-library/src/test/java/com/vonage/clientlibrary/SilentAuthAdvancedTest.kt
+++ b/client-library/src/test/java/com/vonage/clientlibrary/SilentAuthAdvancedTest.kt
@@ -113,6 +113,56 @@ class SimBasedAuthzDataTest {
     }
 
     @Test
+    fun `fromJson treats JSON null values for optional string fields as null`() {
+        // Issue 1: JSONObject.optString returns the literal string "null" for JSON null;
+        // optStringOrNull must guard against that.
+        val withJsonNulls = """
+            {
+              "vpResponse": {
+                "id": "gnp",
+                "format": "dc-authorization+sd-jwt",
+                "meta": {
+                  "vct_values": [],
+                  "credential_authorization_jwt": "aaa.bbb.ccc"
+                },
+                "claims": []
+              },
+              "androidAppUrl": null,
+              "appInfoJwt": null,
+              "iOSAppClipUrl": null
+            }
+        """.trimIndent()
+        val data = SimBasedAuthzData.fromJson(JSONObject(withJsonNulls))
+        assertNull(data.androidAppUrl)
+        assertNull(data.appInfoJwt)
+        assertNull(data.iOSAppClipUrl)
+    }
+
+    @Test
+    fun `fromJson treats empty string values for optional string fields as null`() {
+        val withEmptyStrings = """
+            {
+              "vpResponse": {
+                "id": "gnp",
+                "format": "dc-authorization+sd-jwt",
+                "meta": {
+                  "vct_values": [],
+                  "credential_authorization_jwt": "aaa.bbb.ccc"
+                },
+                "claims": []
+              },
+              "androidAppUrl": "",
+              "appInfoJwt": "",
+              "iOSAppClipUrl": ""
+            }
+        """.trimIndent()
+        val data = SimBasedAuthzData.fromJson(JSONObject(withEmptyStrings))
+        assertNull(data.androidAppUrl)
+        assertNull(data.appInfoJwt)
+        assertNull(data.iOSAppClipUrl)
+    }
+
+    @Test
     fun `fromJson throws IllegalArgumentException when vpResponse is missing`() {
         assertThrows(IllegalArgumentException::class.java) {
             SimBasedAuthzData.fromJson(JSONObject("{}"))
@@ -383,5 +433,89 @@ class SilentAuthAdvancedManagerTest {
 
         val error = result as SaaResult.Error
         assertEquals(SaaErrorCode.TOKEN_TOO_LARGE, error.code)
+    }
+
+    // ------------------------------------------------------------------
+    // Provider-error mapping
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `provider GetCredentialUnsupportedException falls back to DeepLinkRequired when androidAppUrl present`() {
+        every { mockProvider.isNativePathAvailable(any()) } returns true
+        every { mockProvider.requestToken(any(), any(), any()) } answers {
+            val cb = thirdArg<(String?, Exception?) -> Unit>()
+            cb(null, androidx.credentials.exceptions.GetCredentialUnsupportedException("unsupported"))
+        }
+
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.requestOperatorToken(
+            mockActivity,
+            makeAuthzData(
+                androidAppUrl = "https://carrier.example.com/app",
+                appInfoJwt = "my-app-jwt"
+            )
+        ) { result = it }
+
+        val deepLink = result as SaaResult.DeepLinkRequired
+        assertEquals("https://carrier.example.com/app", deepLink.intent.data?.toString())
+        // Issue 3: appInfoJwt extra must also be set on the error-fallback deep-link path
+        assertEquals("my-app-jwt", deepLink.intent.getStringExtra(SilentAuthAdvancedManager.EXTRA_APP_INFO_JWT))
+    }
+
+    @Test
+    fun `provider GetCredentialUnsupportedException returns UNSUPPORTED_NETWORK when no androidAppUrl`() {
+        every { mockProvider.isNativePathAvailable(any()) } returns true
+        every { mockProvider.requestToken(any(), any(), any()) } answers {
+            val cb = thirdArg<(String?, Exception?) -> Unit>()
+            cb(null, androidx.credentials.exceptions.GetCredentialUnsupportedException("unsupported"))
+        }
+
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.requestOperatorToken(mockActivity, makeAuthzData()) { result = it }
+
+        val error = result as SaaResult.Error
+        assertEquals(SaaErrorCode.UNSUPPORTED_NETWORK, error.code)
+    }
+
+    @Test
+    fun `provider GetCredentialCancellationException surfaces CANCELLED even when androidAppUrl present`() {
+        // Issue 2: cancellation must NOT re-launch the carrier app behind the user's back
+        every { mockProvider.isNativePathAvailable(any()) } returns true
+        every { mockProvider.requestToken(any(), any(), any()) } answers {
+            val cb = thirdArg<(String?, Exception?) -> Unit>()
+            cb(null, androidx.credentials.exceptions.GetCredentialCancellationException("user cancelled"))
+        }
+
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.requestOperatorToken(
+            mockActivity,
+            makeAuthzData(androidAppUrl = "https://carrier.example.com/app")
+        ) { result = it }
+
+        val error = result as SaaResult.Error
+        assertEquals(SaaErrorCode.CANCELLED, error.code)
+    }
+
+    @Test
+    fun `provider generic exception surfaces UNKNOWN even when androidAppUrl present`() {
+        // Issue 2: unrelated errors must NOT re-route to deep-link
+        every { mockProvider.isNativePathAvailable(any()) } returns true
+        every { mockProvider.requestToken(any(), any(), any()) } answers {
+            val cb = thirdArg<(String?, Exception?) -> Unit>()
+            cb(null, RuntimeException("network blew up"))
+        }
+
+        val manager = SilentAuthAdvancedManager(mockProvider)
+        var result: SaaResult? = null
+        manager.requestOperatorToken(
+            mockActivity,
+            makeAuthzData(androidAppUrl = "https://carrier.example.com/app")
+        ) { result = it }
+
+        val error = result as SaaResult.Error
+        assertEquals(SaaErrorCode.UNKNOWN, error.code)
     }
 }

--- a/client-library/src/test/java/com/vonage/clientlibrary/VGCellularRequestClientTest.kt
+++ b/client-library/src/test/java/com/vonage/clientlibrary/VGCellularRequestClientTest.kt
@@ -1,5 +1,6 @@
 package com.vonage.clientlibrary
 
+import android.app.Activity
 import android.content.Context
 import com.vonage.clientlibrary.network.NetworkManager
 import io.mockk.*
@@ -134,5 +135,72 @@ class VGCellularRequestClientTest {
         client.getCellularStatus()
 
         verify(exactly = 1) { mockNm.getCellularStatus() }
+    }
+
+    // ------------------------------------------------------------------
+    // SAA: requestSilentAuthAdvancedToken()
+    // ------------------------------------------------------------------
+
+    @OptIn(ExperimentalSaaApi::class)
+    @Test
+    fun `requestSilentAuthAdvancedToken delegates to SilentAuthAdvancedManager`() {
+        val client = buildClient()
+        val mockActivity = mockk<Activity>(relaxed = true)
+        val mockManager = mockk<SilentAuthAdvancedManager>(relaxed = true)
+
+        val authzData = SimBasedAuthzData(
+            vpResponse = VpResponse(
+                id = "gnp",
+                format = "dc-authorization+sd-jwt",
+                meta = VpMeta(
+                    vctValues = listOf("number-verification/device-phone-number/ts43"),
+                    credentialAuthorizationJwt = "aaa.bbb.ccc"
+                ),
+                claims = emptyList()
+            ),
+            androidAppUrl = null,
+            appInfoJwt = null
+        )
+
+        val slot = slot<(SaaResult) -> Unit>()
+        every { mockManager.requestOperatorToken(any(), any(), capture(slot)) } answers {
+            slot.captured(SaaResult.Success("test-token"))
+        }
+
+        var result: SaaResult? = null
+        client.requestSilentAuthAdvancedToken(mockActivity, authzData, mockManager) { result = it }
+
+        verify(exactly = 1) { mockManager.requestOperatorToken(mockActivity, authzData, any()) }
+        assertEquals(SaaResult.Success("test-token"), result)
+    }
+
+    @OptIn(ExperimentalSaaApi::class)
+    @Test
+    fun `requestSilentAuthAdvancedToken passes error result through`() {
+        val client = buildClient()
+        val mockActivity = mockk<Activity>(relaxed = true)
+        val mockManager = mockk<SilentAuthAdvancedManager>(relaxed = true)
+
+        val authzData = SimBasedAuthzData(
+            vpResponse = VpResponse(
+                id = "gnp",
+                format = "dc-authorization+sd-jwt",
+                meta = VpMeta(vctValues = emptyList(), credentialAuthorizationJwt = "jwt"),
+                claims = emptyList()
+            ),
+            androidAppUrl = null,
+            appInfoJwt = null
+        )
+
+        val slot = slot<(SaaResult) -> Unit>()
+        every { mockManager.requestOperatorToken(any(), any(), capture(slot)) } answers {
+            slot.captured(SaaResult.Error(SaaErrorCode.UNSUPPORTED_NETWORK, "no carrier support"))
+        }
+
+        var result: SaaResult? = null
+        client.requestSilentAuthAdvancedToken(mockActivity, authzData, mockManager) { result = it }
+
+        val error = result as SaaResult.Error
+        assertEquals(SaaErrorCode.UNSUPPORTED_NETWORK, error.code)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.6"
 activityCompose = "1.9.2"
 composeBom = "2024.04.01"
+credentials = "1.5.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -31,6 +32,8 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
+androidx-credentials-play = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentials" }
 
 [plugins]
 android-library = { id = "com.android.library", version.ref = "agp" }


### PR DESCRIPTION
Adds GSMA TS.43 SIM-based authentication support as an experimental API. SAA works over Wi-Fi, VPN, and cellular — no data session forcing needed.

New files:
- ExperimentalSaaApi.kt       — @RequiresOptIn annotation for all SAA API surface
- SimBasedAuthzData.kt        — Data models for the sim_based_authz_data payload
                                (SimBasedAuthzData, VpResponse, VpMeta, VpClaim)
- SaaResult.kt                — SaaResult sealed class (Success, DeepLinkRequired, Error)
                                SaaErrorCode enum, SaaTokenProvider interface
- DefaultSaaTokenProvider.kt  — Default TS.43 impl via androidx.credentials DigitalCredential API
- SilentAuthAdvancedManager.kt — Orchestrates native TS.43 path, deep-link fallback,
                                 virtual operator test support, and token size validation

Modified:
- VGCellularRequestClient.kt  — Exposes requestSilentAuthAdvancedToken()
- build.gradle.kts            — Version 1.3.0-alpha01, adds androidx.credentials deps
- libs.versions.toml          — Adds credentials 1.5.0

Tests (SilentAuthAdvancedTest.kt):
- JSON parsing for all SimBasedAuthzData fields
- Virtual operator: even last digit succeeds, odd fails
- Native TS.43 happy path, TOKEN_TOO_LARGE, UNKNOWN error
- Deep-link fallback path and appInfoJwt extra
- UNSUPPORTED_NETWORK when no fallback available
- handleDeepLinkResult: success, null/blank token, oversized token